### PR TITLE
Make sure Rtools is installed on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ install:
 
 # Adapt as necessary starting from here
 
+environment:
+  global:
+    USE_RTOOLS: true
+
 build_script:
   - travis-tool.sh install_deps
 

--- a/tests/testthat/test-drive-path.R
+++ b/tests/testthat/test-drive-path.R
@@ -13,9 +13,6 @@ test_that("split_path() strips leading ~ or ~/ or /, then splits", {
 })
 
 test_that("form_query() handles paths w/ all combos of dir and leaf piece(s)", {
-  ## currently, appveyor cannot build dev version of glue
-  skip_on_appveyor()
-
   expect_identical(
     ## path = a/b/
     form_query(c("a", "b"), TRUE),


### PR DESCRIPTION
Allows us to rely on development packages that will need to be built, i.e. to have packages in Remotes in DESCRIPTION