### PR TITLE
Bug fix get_leaf(); fixes #40

### DIFF
--- a/R/drive_mkdir.R
+++ b/R/drive_mkdir.R
@@ -48,8 +48,3 @@ drive_mkdir <- function(dir = NULL, path = NULL, verbose = TRUE) {
   invisible(drive_file(proc_res$id))
 }
 
-## trailing slash indicates that 'path' is path to a folder
-## which can simplify the work inside get_leaf()
-append_slash <- function(path) {
-  if (grepl("/$", path)) path else paste0(path, "/")
-}

--- a/R/drive_path.R
+++ b/R/drive_path.R
@@ -127,10 +127,6 @@ form_query <- function(path_pieces, leaf_is_folder = FALSE) {
   glue::collapse(c(leaf_q, dirs_q), last = " or ")
 }
 
-require_length <- function(paths, len) {
-  paths %>% purrr::keep(~ length(.x) == len)
-}
-
 rootwise_parent <- function(paths) {
   ## retain only paths that end with root_id <==> not NA
   paths <- paths %>% purrr::keep(~ !is.na(last(.x)))

--- a/R/drive_path.R
+++ b/R/drive_path.R
@@ -39,6 +39,9 @@ get_leaf <- function(path = NULL) {
   ## for each candidate, enumerate all upward paths, hopefully to root
   root_path <- leaf_id %>%
     purrr::map(pth, kids = hits$id, elders = hits$parents, stop_value = root_id)
+  ## retain candidate paths with d + 1 elements = d path pieces + root_id
+  root_path <- root_path %>%
+    purrr::map(require_length, len = d + 1)
   ## for each candidate, get an immediate parent on a path back to root
   ## will be NA is there is no such path
   root_parent <- root_path %>%
@@ -120,6 +123,10 @@ form_query <- function(path_pieces, leaf_is_folder = FALSE) {
     dir_pieces = collapse2(crop(nms, !leaf_is_folder), sep = " or ")
   )
   glue::collapse(c(leaf_q, dirs_q), last = " or ")
+}
+
+require_length <- function(paths, len) {
+  paths %>% purrr::keep(~ length(.x) == len)
 }
 
 rootwise_parent <- function(paths) {

--- a/R/drive_path.R
+++ b/R/drive_path.R
@@ -30,42 +30,44 @@ get_leaf <- function(path = NULL) {
   ## guarantee: we have found at least one item with correct name for
   ## each piece of path
 
-  hits$depth <- match(hits$name, path_pieces)
-  hits <- hits[order(hits$depth), ]
-
   ## leaf candidate(s)
-  leaf_id <- hits$id[hits$depth == d]
+  leaf_id <- hits$id[hits$name == last(path_pieces)]
 
   ## for each candidate, enumerate all upward paths, hopefully to root
   root_path <- leaf_id %>%
     purrr::map(pth, kids = hits$id, elders = hits$parents, stop_value = root_id)
-  ## retain candidate paths with d + 1 elements = d path pieces + root_id
-  root_path <- root_path %>%
-    purrr::map(require_length, len = d + 1)
-  ## for each candidate, get an immediate parent on a path back to root
-  ## will be NA is there is no such path
-  root_parent <- root_path %>%
-    purrr::map_chr(rootwise_parent)
-  root_path_exists <- !is.na(root_parent)
 
-  if (sum(root_path_exists) > 1) {
+  ## put into a tibble, one row per candidate path
+  leaf_tbl <- tibble::tibble(
+    id = rep(leaf_id, lengths(root_path)),
+    root_path = purrr::flatten(root_path)
+  )
+  leaf_tbl$path <- purrr::map_chr(
+    leaf_tbl$root_path,
+    ~ glue::collapse(rev(hits$name[match(crop(.x, 1), hits$id)]), sep = "/")
+  )
+
+  ## retain candidate paths that match input path
+  keep_me <- which(strip_slash(path) == leaf_tbl$path)
+
+  if (length(keep_me) > 1) {
     line0 <- glue::glue("The path '{path}' identifies more than one file:")
     lines <- glue::glue_data(
-      hits[hits$id %in% leaf_id[root_path_exists], ],
+      hits[hits$id %in% leaf_id[keep_me], ],
       "File of type {type}, with id {id}."
     )
     stop(glue::collapse(c(line0, lines), "\n"), call. = FALSE)
   }
 
-  if (sum(root_path_exists) < 1) {
+  if (length(keep_me) < 1) {
     stop(glue::glue("The path '{path}' does not exist.", call. = FALSE))
   }
 
-  i <- which(hits$id == leaf_id[root_path_exists])
+  i <- which(hits$id == leaf_id[keep_me])
   list(
     id = hits$id[i],
     mimeType = hits$gfile[[i]][["mimeType"]],
-    parent_id = root_parent
+    parent_id = leaf_tbl[[keep_me, "root_path"]][2]
   )
 }
 
@@ -135,4 +137,14 @@ rootwise_parent <- function(paths) {
   if (length(paths) == 0) return(NA_character_)
   ## return one -- of possibly many -- direct parents
   paths[[1]][2]
+}
+
+## "a/b/c" and "a/b/c/" both return "a/b/c/"
+append_slash <- function(path) {
+  ifelse(grepl("/$", path), path, paste0(path, "/"))
+}
+
+## "a/b/c" and "a/b/c/" both return "a/b/c"
+strip_slash <- function(path) {
+  ifelse(grepl("/$", path), gsub("/$", "", path), path)
 }

--- a/tests/testthat/test-drive_list.R
+++ b/tests/testthat/test-drive_list.R
@@ -166,6 +166,47 @@ test_that("get_leaf() is not confused by same-named leafs at different depths", 
     purrr::map(drive_delete)
 })
 
+test_that("get_leaf() is not confused by nested same-named things", {
+
+  skip_on_appveyor()
+  skip_on_travis()
+
+  # +-- foo
+  # | +-- foo
+  foo_1_id <- drive_mkdir("foo")$id
+  foo_2_id <- drive_mkdir("foo", path = "foo/")$id
+  expect_identical(get_leaf("foo")$id, foo_1_id)
+  expect_identical(get_leaf("foo/foo/")$id, foo_2_id)
+
+  foo_1_id %>%
+    purrr::map(drive_file) %>%
+    purrr::map(drive_delete)
+})
+
+test_that("get_leaf() is not confused by paths w/ swapped interior folders", {
+
+  skip_on_appveyor()
+  skip_on_travis()
+
+  # +-- foo
+  # | +-- bar
+  #   | +-- baz
+  # +-- bar
+  # | +-- foo
+  #   | +-- baz
+  foo_1_id <- drive_mkdir("foo")$id
+  bar_1_id <- drive_mkdir("bar", path = "foo/")$id
+  baz_1_id <- drive_mkdir("baz", path = "foo/bar/")$id
+  bar_2_id <- drive_mkdir("bar")$id
+  foo_2_id <- drive_mkdir("foo", path = "bar/")$id
+  baz_2_id <- drive_mkdir("baz", path = "bar/foo/")$id
+  expect_identical(get_leaf("foo/bar/baz")$id, baz_1_id)
+  expect_identical(get_leaf("bar/foo/baz/")$id, baz_2_id)
+
+  c(foo_1_id, bar_2_id) %>%
+    purrr::map(drive_file) %>%
+    purrr::map(drive_delete)
+})
 
 ## TO DO: add this as a test
 ## path = foo/bar/baz

--- a/tests/testthat/test-drive_list.R
+++ b/tests/testthat/test-drive_list.R
@@ -128,6 +128,7 @@ test_that("drive_list errors with two folders of the same name in the same locat
     purrr::map(drive_file) %>%
     purrr::map(drive_delete)
 })
+
 test_that("drive_list errors with two folders of the same name in the root, not unique", {
 
   skip_on_appveyor()
@@ -147,6 +148,24 @@ test_that("drive_list errors with two folders of the same name in the root, not 
 
 })
 
+test_that("get_leaf() is not confused by same-named leafs at different depths", {
+
+  skip_on_appveyor()
+  skip_on_travis()
+
+  # +-- foo
+  # | +-- bar
+  # +-- bar
+  foo_id <- drive_mkdir("foo")$id
+  bar_id <- drive_mkdir("bar", path = "foo/")$id
+  bar_2_id <- drive_mkdir("bar")$id
+  expect_identical(get_leaf("foo/bar/")$id, bar_id)
+
+  c(foo_id, bar_2_id) %>%
+    purrr::map(drive_file) %>%
+    purrr::map(drive_delete)
+})
+
 
 ## TO DO: add this as a test
 ## path = foo/bar/baz
@@ -155,7 +174,7 @@ test_that("drive_list errors with two folders of the same name in the root, not 
 
 ## TO DO: add this as a test
 ## path = "jt01/jt02/jt03" or "jt01/jt02/jt03/"
-## "jt01/jt02/jt03" exists where jt03 is´a folder holding a file jt04
+## "jt01/jt02/jt03" exists where jt03 is a folder holding a file jt04
 ## "jt01/jt02/jt03" exists where jt03 is a file
 ## so there are two folders named jt02 inside jt01
 ## make sure that path = "jt01/jt02" errors because ambiguous

--- a/tests/testthat/test-drive_list.R
+++ b/tests/testthat/test-drive_list.R
@@ -183,7 +183,7 @@ test_that("get_leaf() is not confused by nested same-named things", {
     purrr::map(drive_delete)
 })
 
-test_that("get_leaf() is not confused by paths w/ swapped interior folders", {
+test_that("get_leaf() is not confused by differently ordered non-leaf folders", {
 
   skip_on_appveyor()
   skip_on_travis()


### PR DESCRIPTION
This is a fix for #40 based on path length.

I still need to address this point from #40 and will borrow your approach from #41.

> Also, when checking through the path, match here doesn't allow for nested folders with the same name. For example if we had "foo/foo", which is perfectly logical, match only matches the first, so we would have depth 1 for both, where they should each be listed as both depth 1 and 2.