### PR TITLE
update docs to reflect drive_upload change (#28)

### DIFF
--- a/R/drive_upload.R
+++ b/R/drive_upload.R
@@ -5,14 +5,9 @@
 #'   the file
 #' @param overwrite logical, do you want to overwrite file already on Google
 #'   Drive
-#' @param type if type = `NULL`, will force type as follows:
-#' * **document**: .doc, .docx, .txt, .rtf., .html, .odt, .pdf, .jpeg, .png, .gif,.bmp
-#' * **spreadsheet**: .xls, .xlsx, .csv, .tsv, .tab, .xlsm, .xlt, .xltx, .xltm,
-#'   .ods
-#' * **presentation**: .opt, .ppt, .pptx, .pptm
-#'
-#'  otherwise you can specify `document`, `spreadsheet`, or `presentation`. Files with no extension will
-#'   be assumed to be a `folder`
+#' @param type if type = `NULL`, will upload as a non-Google Drive document
+#'  otherwise you can specify `document`, `spreadsheet`, or `presentation`.
+#'  Files with no extension will be assumed to be a `folder`.
 #' @param ... name-value pairs to query the API
 #' @param verbose logical, indicating whether to print informative messages
 #'   (default `TRUE`)

--- a/man/drive_upload.Rd
+++ b/man/drive_upload.Rd
@@ -16,16 +16,9 @@ the file}
 \item{overwrite}{logical, do you want to overwrite file already on Google
 Drive}
 
-\item{type}{if type = \code{NULL}, will force type as follows:
-\itemize{
-\item \strong{document}: .doc, .docx, .txt, .rtf., .html, .odt, .pdf, .jpeg, .png, .gif,.bmp
-\item \strong{spreadsheet}: .xls, .xlsx, .csv, .tsv, .tab, .xlsm, .xlt, .xltx, .xltm,
-.ods
-\item \strong{presentation}: .opt, .ppt, .pptx, .pptm
-}
-
-otherwise you can specify \code{document}, \code{spreadsheet}, or \code{presentation}. Files with no extension will
-be assumed to be a \code{folder}}
+\item{type}{if type = \code{NULL}, will upload as a non-Google Drive document
+otherwise you can specify \code{document}, \code{spreadsheet}, or \code{presentation}.
+Files with no extension will be assumed to be a \code{folder}.}
 
 \item{...}{name-value pairs to query the API}
 


### PR DESCRIPTION
when I added the mime type tibble, I changed how `drive_upload()` determines the file type (it used to default to a Google Drive type, and now defaults to the type in the tibble) - I forgot to update the documentation to reflect this change.