### PR TITLE
Don't let codecov checks fail

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,9 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: 5%
+    patch:
+      default:
+        target: 5%


### PR DESCRIPTION
I want codecov reporting but don't want it to be the cause of check failure, i.e. the ❌ for a commit or PR. Let's see if we like this.