### PR TITLE
Make test file names unique to user

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,4 +1,5 @@
 CLEAN <- SETUP <- FALSE
+isFALSE <- function(x) identical(x, FALSE)
 
 ## inspired by developments over in gh
 ## https://github.com/r-lib/gh/blob/master/tests/testthat/helper-offline.R
@@ -41,6 +42,7 @@ skip_if_no_token <- (function() {
 ## call it once here, so message re: token is not muffled by test_that()
 tryCatch(skip_if_no_token(), skip = function(x) NULL)
 
-nm_fun <- function(slug) {
-  function(x) paste(paste0(x, slug), collapse = "/")
+nm_fun <- function(slug, user = Sys.info()["user"]) {
+  y <- purrr::compact(list(slug, user))
+  function(x) as.character(glue::collapse(c(x, y), sep = "-"))
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -46,3 +46,5 @@ nm_fun <- function(slug, user = Sys.info()["user"]) {
   y <- purrr::compact(list(slug, user))
   function(x) as.character(glue::collapse(c(x, y), sep = "-"))
 }
+
+message("Test file naming scheme:\n  * ", nm_fun("TEST-FILE-SLUG")("foo"))

--- a/tests/testthat/test-drive_download.R
+++ b/tests/testthat/test-drive_download.R
@@ -1,7 +1,7 @@
 context("Download files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-download")
+nm_ <- nm_fun("TEST-drive-download", NULL)
 
 # ---- clean ----
 if (CLEAN) {
@@ -35,6 +35,7 @@ test_that("drive_download() downloads a file", {
   skip_if_no_token()
   skip_if_offline()
   on.exit(unlink("description.txt"))
+
   expect_message(
     drive_download(file = nm_("DESC"), path = "description.txt"),
     "File downloaded"

--- a/tests/testthat/test-drive_find.R
+++ b/tests/testthat/test-drive_find.R
@@ -1,12 +1,12 @@
 context("Find files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("TEST-drive-find")
+nm_ <- nm_fun("TEST-drive-find", NULL)
 
 # ---- clean ----
 if (CLEAN) {
   drive_trash(c(
-    nm_("foo"),
+    nm_("find-me"),
     nm_("this-should-not-exist")
   ))
 }

--- a/tests/testthat/test-drive_find.R
+++ b/tests/testthat/test-drive_find.R
@@ -1,7 +1,7 @@
 context("Find files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-find")
+nm_ <- nm_fun("TEST-drive-find")
 
 # ---- clean ----
 if (CLEAN) {
@@ -13,7 +13,7 @@ if (CLEAN) {
 
 # ---- setup ----
 if (SETUP) {
-  drive_mkdir(nm_("foo"))
+  drive_mkdir(nm_("find-me"))
 }
 
 # ---- tests ----
@@ -43,9 +43,10 @@ test_that("drive_find() filters for the regex in `pattern`", {
   skip_if_no_token()
   skip_if_offline()
 
-  ## this should be able to find the folder we created, foo-TEST-drive-search
-  expect_identical(drive_find(pattern = nm_("foo"))$name, nm_("foo"))
-
+  expect_identical(
+    drive_find(pattern = nm_("find-me"))$name,
+    nm_("find-me")
+  )
 })
 
 test_that("drive_find() errors for nonsense in `n_max`", {

--- a/tests/testthat/test-drive_get.R
+++ b/tests/testthat/test-drive_get.R
@@ -1,7 +1,7 @@
 context("Get files by path or id")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-get")
+nm_ <- nm_fun("TEST-drive-get", NULL)
 
 # ---- clean ----
 if (CLEAN) {

--- a/tests/testthat/test-drive_ls.R
+++ b/tests/testthat/test-drive_ls.R
@@ -1,7 +1,7 @@
 context("List folder contents")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-ls")
+nm_ <- nm_fun("TEST-drive-ls", NULL)
 
 # ---- clean ----
 if (CLEAN) {

--- a/tests/testthat/test-drive_mkdir.R
+++ b/tests/testthat/test-drive_mkdir.R
@@ -1,7 +1,8 @@
 context("Make folders")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-mkdir")
+me_ <- nm_fun("TEST-drive-mkdir")
+nm_ <- nm_fun("TEST-drive-mkdir", NULL)
 
 # ---- clean ----
 if (CLEAN) {
@@ -45,67 +46,67 @@ test_that("drive_mkdir() errors if parent exists but is not a folder", {
 test_that("drive_mkdir() creates a folder in root folder", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("I-live-in-root")))
+  on.exit(drive_rm(me_("I-live-in-root")))
 
-  out <- drive_mkdir(nm_("I-live-in-root"))
+  out <- drive_mkdir(me_("I-live-in-root"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("I-live-in-root"))
+  expect_identical(out$name, me_("I-live-in-root"))
 })
 
 test_that("drive_mkdir() accepts parent folder given as dribble", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("a")))
+  on.exit(drive_rm(me_("a")))
 
   PARENT <- drive_get(nm_("OMNI-PARENT"))
-  out <- drive_mkdir(PARENT, nm_("a"))
+  out <- drive_mkdir(PARENT, me_("a"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("a"))
+  expect_identical(out$name, me_("a"))
 })
 
 test_that("drive_mkdir() accepts parent folder given as file id", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("b")))
+  on.exit(drive_rm(me_("b")))
 
   PARENT <- drive_get(nm_("OMNI-PARENT"))
-  out <- drive_mkdir(as_id(PARENT$id), nm_("b"))
+  out <- drive_mkdir(as_id(PARENT$id), me_("b"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("b"))
+  expect_identical(out$name, me_("b"))
 })
 
 test_that("drive_mkdir() accepts name as part of path", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("c")))
+  on.exit(drive_rm(me_("c")))
 
-  out <- drive_mkdir(file.path(nm_("OMNI-PARENT"), nm_("c")))
+  out <- drive_mkdir(file.path(nm_("OMNI-PARENT"), me_("c")))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("c"))
+  expect_identical(out$name, me_("c"))
 })
 
 test_that("drive_mkdir() accepts name as part of path with trailing slash", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("d")))
+  on.exit(drive_rm(me_("d")))
 
-  out <- drive_mkdir(file.path(nm_("OMNI-PARENT"), nm_("d"), ""))
+  out <- drive_mkdir(file.path(nm_("OMNI-PARENT"), me_("d"), ""))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("d"))
+  expect_identical(out$name, me_("d"))
 })
 
 test_that("drive_mkdir() accepts path and name", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(c(nm_("e"), nm_("f"))))
+  on.exit(drive_rm(c(me_("e"), me_("f"))))
 
   ## no trailing slash on path
-  out <- drive_mkdir(nm_("OMNI-PARENT"), nm_("e"))
+  out <- drive_mkdir(nm_("OMNI-PARENT"), me_("e"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("e"))
+  expect_identical(out$name, me_("e"))
 
   ## yes trailing slash on path
-  out <- drive_mkdir(file.path(nm_("OMNI-PARENT"), ""), nm_("f"))
+  out <- drive_mkdir(file.path(nm_("OMNI-PARENT"), ""), me_("f"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("f"))
+  expect_identical(out$name, me_("f"))
 })

--- a/tests/testthat/test-drive_mv.R
+++ b/tests/testthat/test-drive_mv.R
@@ -1,7 +1,8 @@
 context("Move files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-mv")
+me_ <- nm_fun("TEST-drive-mv")
+nm_ <- nm_fun("TEST-drive-mv", NULL)
 
 # ---- clean ----
 if (CLEAN) {
@@ -21,15 +22,15 @@ if (SETUP) {
 test_that("drive_mv() can rename file", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("DESC-renamed")))
+  on.exit(drive_rm(me_("DESC-renamed")))
 
   renamee <- drive_upload(
     system.file("DESCRIPTION"),
-    nm_("DESC"),
+    me_("DESC"),
     verbose = FALSE
   )
   expect_message(
-    out <- drive_mv(renamee, name = nm_("DESC-renamed")),
+    out <- drive_mv(renamee, name = me_("DESC-renamed")),
     "File renamed"
   )
   expect_s3_class(out, "dribble")
@@ -39,13 +40,9 @@ test_that("drive_mv() can rename file", {
 test_that("drive_mv() can move a file into a folder given as path", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("DESC")))
+  on.exit(drive_rm(me_("DESC")))
 
-  movee <- drive_upload(
-    system.file("DESCRIPTION"),
-    nm_("DESC"),
-    verbose = FALSE
-  )
+  movee <- drive_upload(system.file("DESCRIPTION"), me_("DESC"))
 
   ## path is detected as folder (must have trailing slash)
   expect_message(
@@ -61,13 +58,9 @@ test_that("drive_mv() can move a file into a folder given as path", {
 test_that("drive_mv() can move a file into a folder given as dribble", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("DESC")))
+  on.exit(drive_rm(me_("DESC")))
 
-  movee <- drive_upload(
-    system.file("DESCRIPTION"),
-    nm_("DESC"),
-    verbose = FALSE
-  )
+  movee <- drive_upload(system.file("DESCRIPTION"), me_("DESC"))
 
   destination <- drive_get(nm_("move-files-into-me"))
   expect_message(
@@ -82,16 +75,12 @@ test_that("drive_mv() can move a file into a folder given as dribble", {
 test_that("drive_mv() can rename and move, using `path` and `name`", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("DESC-renamed")))
+  on.exit(drive_rm(me_("DESC-renamed")))
 
-  movee <- drive_upload(
-    system.file("DESCRIPTION"),
-    nm_("DESC"),
-    verbose = FALSE
-  )
+  movee <- drive_upload(system.file("DESCRIPTION"), me_("DESC"))
 
   expect_message(
-    out <- drive_mv(movee, nm_("move-files-into-me"), nm_("DESC-renamed")),
+    out <- drive_mv(movee, nm_("move-files-into-me"), me_("DESC-renamed")),
     "File renamed and moved"
   )
   expect_s3_class(out, "dribble")
@@ -101,18 +90,14 @@ test_that("drive_mv() can rename and move, using `path` and `name`", {
 test_that("drive_mv() can rename and move, using `path` only", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("DESC-renamed")))
+  on.exit(drive_rm(me_("DESC-renamed")))
 
-  movee <- drive_upload(
-    system.file("DESCRIPTION"),
-    nm_("DESC"),
-    verbose = FALSE
-  )
+  movee <- drive_upload(system.file("DESCRIPTION"), me_("DESC"))
 
   expect_message(
     out <- drive_mv(
       movee,
-      file.path(nm_("move-files-into-me"), nm_("DESC-renamed"))
+      file.path(nm_("move-files-into-me"), me_("DESC-renamed"))
     ),
     "File renamed and moved"
   )

--- a/tests/testthat/test-drive_publish.R
+++ b/tests/testthat/test-drive_publish.R
@@ -1,7 +1,7 @@
 context("Publish files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-publish")
+nm_ <- nm_fun("TEST-drive-publish", NULL)
 
 # ---- clean ----
 if (CLEAN) {
@@ -26,7 +26,6 @@ if (SETUP) {
 
 # ---- tests ----
 test_that("drive_publish() publishes Google Documents", {
-
   skip_if_no_token()
   skip_if_offline()
 
@@ -54,8 +53,7 @@ test_that("drive_publish() publishes Google Documents", {
 })
 
 test_that("drive_publish() publishes Google Sheets", {
-
-  ## we are testing this seperately because revision
+  ## we are testing this separately because revision
   ## history is a bit different for Sheets
   skip_if_no_token()
   skip_if_offline()
@@ -79,7 +77,6 @@ test_that("drive_publish() publishes Google Sheets", {
 })
 
 test_that("drive_publish() fails if the file input is not a Google Drive type", {
-
   skip_if_no_token()
   skip_if_offline()
 

--- a/tests/testthat/test-drive_share.R
+++ b/tests/testthat/test-drive_share.R
@@ -1,7 +1,8 @@
 context("Share files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-share")
+me_ <- nm_fun("TEST-drive-share")
+nm_ <- nm_fun("TEST-drive-share", NULL)
 
 # ---- clean ----
 if (CLEAN) {
@@ -20,12 +21,11 @@ if (SETUP) {
 test_that("drive_share doesn't explicitly fail", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("mirrors-to-share")))
+  on.exit(drive_rm(me_("mirrors-to-share")))
 
   file <- drive_upload(
     R.home('doc/BioC_mirrors.csv'),
-    name = nm_("mirrors-to-share"),
-    verbose = FALSE
+    name = me_("mirrors-to-share")
   )
   ## since we haven't updated the permissions, the permissions
   ## tibble should be just 1 row

--- a/tests/testthat/test-drive_trash.R
+++ b/tests/testthat/test-drive_trash.R
@@ -1,31 +1,41 @@
 context("Trash files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-trash")
+me_ <- nm_fun("TEST-drive-trash")
+nm_ <- nm_fun("TEST-drive-trash", NULL)
 
 # ---- setup ----
 if (SETUP) {
-  drive_mkdir(nm_("foo"))
+  drive_upload(
+    system.file("DESCRIPTION"),
+    nm_("trash-fodder")
+  )
 }
 
 # ---- clean ----
 if (CLEAN) {
-  drive_trash(nm_("foo"))
+  drive_trash(c(
+    nm_("trash-fodder"),
+    me_("trashee")
+  ))
 }
 
 # ---- tests ----
 test_that("drive_trash() moves file to trash and drive_untrash() undoes", {
   skip_if_no_token()
   skip_if_offline()
+  on.exit(drive_rm(me_("trashee")))
 
-  out <- drive_trash(nm_("foo"))
+  trashee <- drive_cp(nm_("trash-fodder"), name = me_("trashee"))
+
+  out <- drive_trash(me_("trashee"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("foo"))
+  expect_identical(out$name, me_("trashee"))
   expect_true(out[["files_resource"]][[1]][["trashed"]])
 
-  out <- drive_untrash(nm_("foo"))
+  out <- drive_untrash(me_("trashee"))
   expect_s3_class(out, "dribble")
-  expect_identical(out$name, nm_("foo"))
+  expect_identical(out$name, me_("trashee"))
   expect_false(out[["files_resource"]][[1]][["trashed"]])
 })
 

--- a/tests/testthat/test-drive_update.R
+++ b/tests/testthat/test-drive_update.R
@@ -1,12 +1,13 @@
 context("Update files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-update")
+me_ <- nm_fun("TEST-drive-update")
+nm_ <- nm_fun("TEST-drive-update", NULL)
 
 # ---- clean ----
 if (CLEAN) {
   drive_trash(c(
-    nm_("update-me"),
+    nm_("update-fodder"),
     nm_("not-unique"),
     nm_("does-not-exist")
   ))
@@ -14,7 +15,7 @@ if (CLEAN) {
 
 # ---- setup ----
 if (SETUP) {
-  drive_upload(system.file("DESCRIPTION"), nm_("update-me"))
+  drive_upload(system.file("DESCRIPTION"), nm_("update-fodder"))
   drive_upload(system.file("DESCRIPTION"), nm_("not-unique"))
   drive_upload(system.file("DESCRIPTION"), nm_("not-unique"))
 }
@@ -23,8 +24,9 @@ if (SETUP) {
 test_that("drive_update() updates file", {
   skip_if_no_token()
   skip_if_offline()
+  on.exit(drive_rm(me_("update-me")))
 
-  updatee <- drive_find(nm_("update-me"))
+  updatee <- drive_cp(nm_("update-fodder"), name = me_("update-me"))
   tmp <- tempfile()
   now <- as.character(Sys.time())
   writeLines(now, tmp)

--- a/tests/testthat/test-drive_upload.R
+++ b/tests/testthat/test-drive_upload.R
@@ -1,7 +1,8 @@
 context("Upload files")
 
 # ---- nm_fun ----
-nm_ <- nm_fun("-TEST-drive-upload")
+me_ <- nm_fun("TEST-drive-upload")
+nm_ <- nm_fun("TEST-drive-upload", NULL)
 
 # ---- clean ----
 if (CLEAN) {
@@ -24,13 +25,13 @@ test_that("drive_upload() detects non-existent file", {
 test_that("drive_upload() places file in non-root folder, with new name", {
   skip_if_no_token()
   skip_if_offline()
-  on.exit(drive_rm(nm_("DESCRIPTION")))
+  on.exit(drive_rm(me_("DESCRIPTION")))
 
   destination <- drive_get(nm_("upload-into-me"))
   uploadee <- drive_upload(
     system.file("DESCRIPTION"),
     path = destination,
-    name = nm_("DESCRIPTION")
+    name = me_("DESCRIPTION")
   )
 
   expect_s3_class(uploadee, "dribble")


### PR DESCRIPTION
This way concurrent tests by travis and appveyor (and @jennybc and @LucyMcGowan) can't interfere with each other.