### PR TITLE
Add LICENSE.md for tidyverse paper

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^vignettes/articles$
 ^revdep$
 ^index\.md$
+^LICENSE\.md$

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2019
-COPYRIGHT HOLDER: Lucy D'Agostino McGowan and Jennifer Bryan and RStudio
+COPYRIGHT HOLDER: RStudio

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2019 Lucy D'Agostino McGowan and Jennifer Bryan and RStudio
+Copyright (c) 2019 RStudio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2019 Lucy D'Agostino McGowan and Jennifer Bryan and RStudio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds license as markdown for tidyverse paper review (n.b. I copied the name wording from the plaintext license, using multiple "and"s, rather than semi-colon delimiting).