### PR TITLE
Update link, add note on invalidity of inputs within examples.

### DIFF
--- a/R/drive_get.R
+++ b/R/drive_get.R
@@ -34,15 +34,16 @@
 #'
 #' @examples
 #' \dontrun{
-#' ## Note many of these will error or return 0-row tibbles unless
-#' ## you replace the inputs with paths or ids which exist on your
-#' ## Drive.
-#'
 #' ## get info about your "My Drive" root folder
 #' drive_get("~/")
 #' ## the API reserves the file id "root" for your root folder
 #' drive_get(id = "root")
 #' drive_get(id = "root") %>% drive_reveal("path")
+#'
+#' ## The examples below are indicative of correct syntax.
+#' ## But note these will generally result in an error or a
+#' ## 0-row dribble, unless you replace the inputs with paths
+#' ## or file ids that exist in your Drive.
 #'
 #' ## multiple names
 #' drive_get(c("abc", "def"))

--- a/R/drive_get.R
+++ b/R/drive_get.R
@@ -14,7 +14,7 @@
 #'
 #' @seealso Wraps the `files.get` endpoint and, if you specify files by name or
 #'   path, also calls `files.list`:
-#'   * <https://developers.google.com/drive/v3/reference/files/update>
+#'   * <https://developers.google.com/drive/v3/reference/files/get>
 #'   * <https://developers.google.com/drive/v3/reference/files/list>
 #'
 #' @param path Character vector of path(s) to get. Use a trailing slash to
@@ -34,6 +34,10 @@
 #'
 #' @examples
 #' \dontrun{
+#' ## Note many of these will error or return 0-row tibbles unless
+#' ## you replace the inputs with paths or ids which exist on your
+#' ## Drive.
+#'
 #' ## get info about your "My Drive" root folder
 #' drive_get("~/")
 #' ## the API reserves the file id "root" for your root folder

--- a/man/drive_get.Rd
+++ b/man/drive_get.Rd
@@ -69,6 +69,10 @@ necessarily equal the number rows in the output.
 
 \examples{
 \dontrun{
+## Note many of these will error or return 0-row tibbles unless
+## you replace the inputs with paths or ids which exist on your
+## Drive.
+
 ## get info about your "My Drive" root folder
 drive_get("~/")
 ## the API reserves the file id "root" for your root folder
@@ -107,7 +111,7 @@ drive_get(c("this.jpg", "that-file"), corpus = "all")
 Wraps the \code{files.get} endpoint and, if you specify files by name or
 path, also calls \code{files.list}:
 \itemize{
-\item \url{https://developers.google.com/drive/v3/reference/files/update}
+\item \url{https://developers.google.com/drive/v3/reference/files/get}
 \item \url{https://developers.google.com/drive/v3/reference/files/list}
 }
 }


### PR DESCRIPTION
- [x] Proofread title, description, and parameters
- [x] Proofread comments in examples
- [x] Ensure comment headings used to divide into scannable sections
- [x] Flag examples that seem overly complex for further review
- [x] ~~Switch out mtcars/iris for something more interesting, or a smaller dataset constructed specifically to illustrate one point.~~
- [x] Review size of example outputs to ensure that you can easily see important rows and cols.
- [x] ~~Datasets should always be tibbles to avoid use of as_tibble() distracting from the main point~~

Checks are what I did, strikethroughs do not seem relevant to the issue. 

### Summary of changes:

* Update a link in `@seealso` to point to the `files.get` endpoint link instead of `files.update`. This seems to be correct because in the preceding text it references files.get/list, not files.update/list.

* Add a note at the top of the examples indicating many will return 0-row tibbles or error unless the function inputs are replaced with paths or ids which exist on the user's Drive.

### Questions:

The return value of the function is shared through a template, which says "An object of class [`dribble`], a tibble with one row per item." It seems reasonable to mention somewhere that if no items are found, it will return a 0-row tibble (and not error/warn). However, I'm unsure if other functions which use the template share this behavior. It looks to be most (all?) of the functions use this template for the return. What's action would you recommend?



Closes #289 