### PR TITLE
Fix broken link for roxygen markdown formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -96,7 +96,7 @@ do things we haven’t made available in the high-level interface.
 
 We use [roxygen2](https://cran.r-project.org/package=roxygen2),
 specifically with the [Markdown
-syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html),
+syntax](https://roxygen2.r-lib.org/articles/rd-formatting.html),
 to create `NAMESPACE` and all `.Rd` files. All edits to documentation
 should be done in roxygen comments above the associated function or
 object.


### PR DESCRIPTION
Fixing this in CONTRIBUTING across multiple packages (see r-lib/usethis#1126).