### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: googledrive
 Title: An Interface to Google Drive
-Version: 1.0.1.9000
+Version: 1.0.1.9001
 Authors@R: 
     c(person(given = "Lucy",
              family = "D'Agostino McGowan",

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -18,6 +18,11 @@
 
 .onLoad <- function(libname, pkgname) {
 
+  .auth <<- gargle::init_AuthState(
+    package     = "googledrive",
+    auth_active = TRUE
+  )
+
   if (requireNamespace("dplyr", quietly = TRUE)) {
     register_s3_method("dplyr", "arrange", "dribble")
     register_s3_method("dplyr", "filter", "dribble")

--- a/R/drive_auth.R
+++ b/R/drive_auth.R
@@ -1,10 +1,8 @@
 ## This file is the interface between googledrive and the
 ## auth functionality in gargle.
 
-.auth <- gargle::init_AuthState(
-  package     = "googledrive",
-  auth_active = TRUE
-)
+# Initialization happens in .onLoad
+.auth <- NULL
 
 ## The roxygen comments for these functions are mostly generated from data
 ## in this list and template text maintained in gargle.


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for https://github.com/r-lib/gargle/pull/157, but is a good change even without that PR.