### PR TITLE
Fix for garbled multibyte Google Sheets title in drive_upload

### DIFF
--- a/R/drive_upload.R
+++ b/R/drive_upload.R
@@ -129,7 +129,8 @@ drive_upload <- function(media,
   meta_file <- withr::local_file(
     tempfile("drive-upload-meta", fileext = ".json")
   )
-  writeLines(jsonlite::toJSON(params), meta_file)
+  ## useBytes is set to avoid unnecessary encoding translation on Windows.
+  writeLines(jsonlite::toJSON(params), meta_file, useBytes = TRUE)
   ## media uploads have unique body situations, so customizing here.
   request$body <- list(
     metadata = httr::upload_file(


### PR DESCRIPTION
## Issue to resolve
On Windows, when uploading a CSV file as a Google Sheets spreadsheet with a sheet title that includes multibyte characters, the title of the resulting uploaded spreadsheet is garbled.

e.g.
```
googledrive::drive_upload(csv_filepath, "Title with multibyte - マルチバイトのタイトル", type = "spreadsheet", overwrite = TRUE)
```

## Cause
This is because of unnecessary encoding translation done by writeLines(), which writes the JSON content to the temporary file for subsequent HTTP upload request. The content of the written JSON file gets garbled. 

## Fix
To avoid the unnecessary encoding translation, I added useBytes = TRUE argument to the writeLines call.
Reference: https://stackoverflow.com/questions/10675360/utf-8-file-output-in-r

## Test
Tested that this resolves the garbling issue on Windows, and also drive_upload keeps working on Mac.

## R CMD check results
```
-- R CMD check results -------------------------------- googledrive 1.0.1.2 ----
Duration: 1m 3.9s

> checking for missing documentation entries ... WARNING
  Undocumented code objects:
    'drive_set_token'
  All user-level objects in a package should have documentation entries.
  See chapter 'Writing R documentation files' in the 'Writing R
  Extensions' manual.

> checking R/sysdata.rda ... OK
   WARNING
  'qpdf' is needed for checks on size reduction of PDFs

> checking package dependencies ... NOTE
  Package suggested but not available for checking: 'spelling'

> checking for future file timestamps ... NOTE
  unable to verify current time

0 errors v | 2 warnings x | 2 notes x
Error: R CMD check found WARNINGs
Execution halted
```
