### PR TITLE
Stop worrying about multiple parent folders

### DIFF
--- a/man/drive_mv.Rd
+++ b/man/drive_mv.Rd
@@ -102,3 +102,9 @@ drive_mv(file, path = "~/", name = "name-squatter", overwrite = TRUE)
 drive_rm(file, folder)
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Makes a metadata-only requiest to the \code{files.update} endpoint:
+\itemize{
+\item \url{https://developers.google.com/drive/v3/reference/files/update}
+}
+}


### PR DESCRIPTION
Closes #356

The docs linked in #356 make this task look more complicated than it seems to be. That is, if the user is trying to do a move they aren't permitted to do, I am happy for them to see an error. I have no ambitions to parse the `capabilities` and try to intercept a request that will fail. Based on personal experience, the value of these `capabilities` and the real-world significance of different values is pretty hard to predict anyway. Want to move a file? Just try it and see what happens.