### PR TITLE
Fix recursive argument in drive_ls

### DIFF
--- a/R/drive_ls.R
+++ b/R/drive_ls.R
@@ -73,7 +73,9 @@ folders_below <- function(id) {
 }
 
 folder_kids_of <- function(id) {
+  shared_drive_id <- drive_get(id)$drive_resource[[1]]$driveId
   drive_find(
+    shared_drive = as_id(shared_drive_id),
     type = "folder",
     q = glue("{sq(id)} in parents"),
     fields = prep_fields(c("kind", "name", "id"))

--- a/R/drive_ls.R
+++ b/R/drive_ls.R
@@ -51,7 +51,7 @@ drive_ls <- function(path = NULL, ..., recursive = FALSE) {
 
   parent <- path[["id"]]
   if (isTRUE(recursive)) {
-    parent <- c(parent, folders_below(parent))
+    parent <- c(parent, folders_below(parent, params[["shared_drive"]]))
   }
   parent <- glue("{sq(parent)} in parents")
   parent <- glue("({or(parent)})")
@@ -60,22 +60,25 @@ drive_ls <- function(path = NULL, ..., recursive = FALSE) {
   exec(drive_find, !!!params)
 }
 
-folders_below <- function(id) {
-  folder_kids <- folder_kids_of(id)
+folders_below <- function(id, shared_drive = NULL) {
+  folder_kids <- folder_kids_of(id, shared_drive = shared_drive)
   if (length(folder_kids) == 0) {
     character()
   } else {
     c(
       folder_kids,
-      unlist(lapply(folder_kids, folders_below), recursive = FALSE)
+      unlist(lapply(
+        folder_kids,
+        folders_below,
+        shared_drive = shared_drive
+      ), recursive = FALSE)
     )
   }
 }
 
-folder_kids_of <- function(id) {
-  shared_drive_id <- drive_get(id)$drive_resource[[1]]$driveId
+folder_kids_of <- function(id, shared_drive = NULL) {
   drive_find(
-    shared_drive = as_id(shared_drive_id),
+    shared_drive = as_id(shared_drive),
     type = "folder",
     q = glue("{sq(id)} in parents"),
     fields = prep_fields(c("kind", "name", "id"))

--- a/tests/testthat/_snaps/drive_ls.md
+++ b/tests/testthat/_snaps/drive_ls.md
@@ -2,8 +2,9 @@
 
     Code
       drive_ls(nm_("this-should-not-exist"))
-    Error <rlang_error>
-      Parent specified via `path` is invalid:
+    Condition
+      Error in `as_parent()`:
+      ! Parent specified via `path` is invalid:
       x Does not exist.
 
 # drive_ls() list contents of the target of a folder shortcut


### PR DESCRIPTION
Fixes #265, the problem related to the use of the recursive argument in drive_ls for shared drives.