### PR TITLE
Modernize the warn_for_verbose() helper

### DIFF
--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -199,9 +199,10 @@ message <- function(...) {
 warn_for_verbose <- function(verbose = TRUE,
                              env = caller_env(),
                              user_env = caller_env(2)) {
-  # this is about whether `verbose` was present in the **user's** call to the
-  # calling function
-  # don't worry about the `verbose = TRUE` default in warn_for_verbose()
+  # This function is not meant to be called directly, so don't worry about its
+  # default of `verbose = TRUE`.
+  # In authentic, indirect usage of this helper, this picks up on whether
+  # `verbose` was present in the **user's** call to the calling function.
   if (!lifecycle::is_present(verbose) || isTRUE(verbose)) {
     return(invisible())
   }
@@ -218,7 +219,7 @@ warn_for_verbose <- function(verbose = TRUE,
     always = identical(env, global_env()),
     id = "googledrive_verbose"
   )
-  # only set the option during organic, indirect usage
+  # only set the option during authentic, indirect usage
   if (!identical(env, global_env())) {
     local_drive_quiet(env = env)
   }

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -216,8 +216,7 @@ warn_for_verbose <- function(verbose = TRUE,
       "googledrive's `verbose` argument will be removed in the future."
     ),
     user_env = user_env,
-    always = identical(env, global_env()),
-    id = "googledrive_verbose"
+    always = identical(env, global_env())
   )
   # only set the option during authentic, indirect usage
   if (!identical(env, global_env())) {

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -207,16 +207,25 @@ warn_for_verbose <- function(verbose = TRUE,
     return(invisible())
   }
 
+  fc <- frame_call(env)
+  caller <- if (is.null(fc)) NULL else call_name(fc)
+  if (is.null(caller)) {
+    what = I("The `verbose` argument")
+  } else {
+    what = glue("{caller}(verbose)")
+  }
+
   lifecycle::deprecate_warn(
     when = "2.0.0",
-    what = I("The `verbose` argument"),
+    what = what,
     details = c(
       "Set `options(googledrive_quiet = TRUE)` to suppress all googledrive messages.",
       "For finer control, use `local_drive_quiet()` or `with_drive_quiet()`.",
       "googledrive's `verbose` argument will be removed in the future."
     ),
     user_env = user_env,
-    always = identical(env, global_env())
+    always = identical(env, global_env()),
+    id = "googledrive_verbose"
   )
   # only set the option during authentic, indirect usage
   if (!identical(env, global_env())) {

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -196,36 +196,31 @@ message <- function(...) {
     instead of {.fun message}")
 }
 
-warn_for_verbose <- function(verbose = TRUE, env = caller_env()) {
+warn_for_verbose <- function(verbose = TRUE,
+                             env = caller_env(),
+                             user_env = caller_env(2)) {
   # this is about whether `verbose` was present in the **user's** call to the
   # calling function
-  # don't worry about the `verbose = TRUE` default here
+  # don't worry about the `verbose = TRUE` default in warn_for_verbose()
   if (!lifecycle::is_present(verbose) || isTRUE(verbose)) {
     return(invisible())
   }
 
-  called_from <- sys.parent(1)
-  if (called_from == 0) {
-    # called from global env, presumably in a test or during development
-    caller <- "some_googledrive_function"
-  } else {
-    called_as <- sys.call(called_from)
-    if (is.call(called_as) && is.symbol(called_as[[1]])) {
-      caller <- as.character(called_as[[1]])
-    } else {
-      caller <- "some_googledrive_function"
-    }
-  }
   lifecycle::deprecate_warn(
     when = "2.0.0",
-    what = glue("{caller}(verbose)"),
+    what = I(cli::format_inline("The {.arg verbose} argument")),
     details = c(
       "Set `options(googledrive_quiet = TRUE)` to suppress all googledrive messages.",
       "For finer control, use `local_drive_quiet()` or `with_drive_quiet()`.",
       "googledrive's `verbose` argument will be removed in the future."
     ),
+    user_env = user_env,
+    always = identical(env, global_env()),
     id = "googledrive_verbose"
   )
-  local_drive_quiet(env = env)
+  # only set the option during organic, indirect usage
+  if (!identical(env, global_env())) {
+    local_drive_quiet(env = env)
+  }
   invisible()
 }

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -208,7 +208,7 @@ warn_for_verbose <- function(verbose = TRUE,
 
   lifecycle::deprecate_warn(
     when = "2.0.0",
-    what = I(cli::format_inline("The {.arg verbose} argument")),
+    what = I("The `verbose` argument"),
     details = c(
       "Set `options(googledrive_quiet = TRUE)` to suppress all googledrive messages.",
       "For finer control, use `local_drive_quiet()` or `with_drive_quiet()`.",

--- a/tests/testthat/_snaps/utils-ui.md
+++ b/tests/testthat/_snaps/utils-ui.md
@@ -4,7 +4,7 @@
       drive_something()
     Condition
       Warning:
-      The `verbose` argument of `drive_something()` is deprecated as of googledrive 2.0.0.
+      The `verbose` argument was deprecated in googledrive 2.0.0.
       i Set `options(googledrive_quiet = TRUE)` to suppress all googledrive messages.
       i For finer control, use `local_drive_quiet()` or `with_drive_quiet()`.
       i googledrive's `verbose` argument will be removed in the future.

--- a/tests/testthat/_snaps/utils-ui.md
+++ b/tests/testthat/_snaps/utils-ui.md
@@ -4,7 +4,7 @@
       drive_something()
     Condition
       Warning:
-      The `verbose` argument was deprecated in googledrive 2.0.0.
+      The `verbose` argument of `drive_something()` is deprecated as of googledrive 2.0.0.
       i Set `options(googledrive_quiet = TRUE)` to suppress all googledrive messages.
       i For finer control, use `local_drive_quiet()` or `with_drive_quiet()`.
       i googledrive's `verbose` argument will be removed in the future.


### PR DESCRIPTION
The motivation for this update is that I will probably feature this as a "deprecation helper" in R Packages. I.e. the type of thing one might do if a deprecation affects a lot of code, such as when googledrive deprecated the `verbose` argument present in virtually every single function in favour of an option.

The helper has been here for quite a while, so I'm updating it to remove some DIY moves and be more idiomatic with modern lifecycle.

How it gets used in almost every function in googledrive:

``` r
drive_create <- function(name,
                         path = NULL,
                         type = NULL,
                         ...,
                         overwrite = NA,
                         verbose = deprecated()) {
  warn_for_verbose(verbose)
  ...
}
```