### PR TITLE
Optionally skip tests requiring 'mockr'

### DIFF
--- a/tests/testthat/test-drive_get_path.R
+++ b/tests/testthat/test-drive_get_path.R
@@ -23,6 +23,7 @@ test_that("get_last_path_part() works", {
 })
 
 test_that("resolve_paths() works, basic scenarios", {
+  skip_if_not_installed("mockr")
   # a -- b -- c -- d
   # ??? -- e
   dr_folder <-
@@ -75,6 +76,7 @@ test_that("resolve_paths() works, basic scenarios", {
 })
 
 test_that("resolve_paths() works, with some name duplication", {
+  skip_if_not_installed("mockr")
   #     name(id)
   #      ___~(1) __
   #     /       \    \


### PR DESCRIPTION
It would be simpler to add the `skip()` inside the helper:

https://github.com/tidyverse/googledrive/blob/b87d89ec5368e7c9800978ae2a8af71a34a20b54/tests/testthat/helper.R#L16-L18

But the tests would have to be rewritten a bit, e.g.

https://github.com/tidyverse/googledrive/blob/b87d89ec5368e7c9800978ae2a8af71a34a20b54/tests/testthat/test-drive_get_path.R#L68-L74

Would probably become:

```r
with_mock(
  root_id = function() "",
  expect_equal(resolve_paths(as_dribble(x), ancestors)$path, "e")
)
```

That format of test looks more natural to me anyway, but filing as is now pending feedback.