### PR TITLE
Use skip_if() over custom approach

### DIFF
--- a/tests/testthat/test-drive_browse.R
+++ b/tests/testthat/test-drive_browse.R
@@ -17,7 +17,7 @@ test_that("drive_link() extracts links for files and Team Drives, alike", {
 })
 
 test_that("drive_browse() passes links through", {
-  if (interactive()) skip("interactive() is TRUE")
+  skip_if(interactive())
   x <- readRDS(test_fixture("mix_of_files_and_teamdrives.rds"))
   expect_identical(drive_browse(x), drive_link(x))
 })


### PR DESCRIPTION
This is functionally basically identical, but it's better to use the specific function since it's there.