### PR TITLE
Recognize Colab links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # googledrive (development version)
 
+* `as_id()` (and hence `drive_download()`) work for Google Colab links (#459, @MichaelChirico).
+
 # googledrive 2.1.1
 
 * `drive_auth(subject =)` is a new argument that can be used with

--- a/R/drive_id-class.R
+++ b/R/drive_id-class.R
@@ -151,9 +151,10 @@ pillar_shaft.drive_id <- function(x, ...) {
 
 ## we anticipate file-id-containing URLs in these forms:
 ##       /d/FILE_ID   Drive file
+##   /drive/FILE_ID   Drive file, from Colab
 ## /folders/FILE_ID   Drive folder
 ##       id=FILE_ID   uploaded blob
-id_regexp <- "(/d/|/folders/|id=)[^/?]+"
+id_regexp <- "(/d/|/drive/(?!folders/|u/)|/folders/|id=)[^/]+"
 
 is_drive_url <- function(x) grepl("^http", x) & grepl(id_regexp, x)
 
@@ -162,10 +163,10 @@ get_one_id <- function(x) {
     return(x)
   }
 
-  id_loc <- regexpr(id_regexp, x)
+  id_loc <- regexpr(id_regexp, x, perl = TRUE)
   if (id_loc == -1) {
     NA_character_
   } else {
-    gsub("/d/|/folders/|id=", "", regmatches(x, id_loc))
+    gsub("/d/|/drive/|/folders/|id=", "", regmatches(x, id_loc))
   }
 }

--- a/tests/testthat/test-drive_id-class.R
+++ b/tests/testthat/test-drive_id-class.R
@@ -146,3 +146,20 @@ test_that("you can't insert invalid strings into a drive_id", {
   expect_true(is_drive_id(x))
   expect_snapshot(x[2] <- "", error = TRUE)
 })
+
+test_that("colab paths (with resource keys) are parsed", {
+  expect_identical(
+    as_id("https://colab.research.google.com/drive/1Dcf35JDcpxXjahcSHVJtQFkBaLhhQWLu?usp=sharing"),
+    as_id("1Dcf35JDcpxXjahcSHVJtQFkBaLhhQWLu")
+  )
+  # without resoucekey
+  expect_identical(
+    as_id("https://colab.research.google.com/drive/1Dcf35JDcpxXjahcSHVJtQFkBaLhhQWLu#scrollTo=Re4OQJePO-3g"),
+    as_id("1Dcf35JDcpxXjahcSHVJtQFkBaLhhQWLu")
+  )
+  # as copied from the Drive UI (Share>Copy Link)
+  expect_identical(
+    as_id("https://colab.research.google.com/drive/1Dcf35JDcpxXjahcSHVJtQFkBaLhhQWLu?resourcekey=0-IfkPRsAwVV1-noFH9jD37Q&usp=drive_link"),
+    as_id("1Dcf35JDcpxXjahcSHVJtQFkBaLhhQWLu")
+  )
+})


### PR DESCRIPTION
Closes #459

Admittedly, this has made a bit of a mess of the regex approach here, but it still passes tests.

What I'm not familiar enough with, is whether _all_ links like `/folders/` are _also_ like `/drive/folders/`, any insight there? If so, maybe we can simplify a bit.

PS is it better to not use a real link to a colab notebook here? 🤔 