### PR TITLE
Switch to base pipe, need R 4.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL: https://googledrive.tidyverse.org,
     https://github.com/tidyverse/googledrive
 BugReports: https://github.com/tidyverse/googledrive/issues
 Depends:
-    R (>= 3.6)
+    R (>= 4.1)
 Imports:
     cli (>= 3.0.0),
     gargle (>= 1.6.0),

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -8,8 +8,8 @@
     "translate_mime_types.csv",
     package = "googledrive",
     mustWork = TRUE
-  ) %>%
-  utils::read.csv(stringsAsFactors = FALSE) %>%
+  ) |>
+  utils::read.csv(stringsAsFactors = FALSE) |>
   as_tibble()
 
 .drive$mime_tbl <-
@@ -19,8 +19,8 @@
     "mime_tbl.csv",
     package = "googledrive",
     mustWork = TRUE
-  ) %>%
-  utils::read.csv(stringsAsFactors = FALSE) %>%
+  ) |>
+  utils::read.csv(stringsAsFactors = FALSE) |>
   as_tibble()
 
 .drive$files_fields <-
@@ -30,8 +30,8 @@
     "files_fields.csv",
     package = "googledrive",
     mustWork = TRUE
-  ) %>%
-  utils::read.csv(stringsAsFactors = FALSE) %>%
+  ) |>
+  utils::read.csv(stringsAsFactors = FALSE) |>
   as_tibble()
 
 # environment to hold other data that is convenient to cache

--- a/R/dribble.R
+++ b/R/dribble.R
@@ -188,7 +188,7 @@ has_drive_resource <- function(x) {
 #' # as_dribble(as_id("0B0Gh-SuuA2nTOGZVTXZTREgwZ2M"))
 #'
 #' # Clean up
-#' drive_find("alfa") %>% drive_rm()
+#' drive_find("alfa") |> drive_rm()
 as_dribble <- function(x, ...) UseMethod("as_dribble")
 
 #' @export

--- a/R/drive_about.R
+++ b/R/drive_about.R
@@ -16,7 +16,7 @@
 #'
 #' # explore the export formats available for Drive files, by MIME type
 #' about <- drive_about()
-#' about[["exportFormats"]] %>%
+#' about[["exportFormats"]] |>
 #'   purrr::map(unlist)
 drive_about <- function() {
   request <- request_generate(

--- a/R/drive_browse.R
+++ b/R/drive_browse.R
@@ -39,7 +39,7 @@ drive_link <- function(file) {
 #' @return Character vector of file hyperlinks, from [drive_link()], invisibly.
 #' @export
 #' @examplesIf drive_has_token() && rlang::is_interactive()
-#' drive_find(n_max = 1) %>% drive_browse()
+#' drive_find(n_max = 1) |> drive_browse()
 drive_browse <- function(file = .Last.value) {
   file <- as_dribble(file)
   links <- drive_link(file)

--- a/R/drive_examples.R
+++ b/R/drive_examples.R
@@ -22,8 +22,8 @@
 
 #' @name drive_examples
 #' @examples
-#' drive_examples_local() %>% basename()
-#' drive_examples_local("chicken") %>% basename()
+#' drive_examples_local() |> basename()
+#' drive_examples_local("chicken") |> basename()
 #' drive_example_local("imdb")
 #'
 #' @examplesIf drive_has_token()

--- a/R/drive_find.R
+++ b/R/drive_find.R
@@ -191,9 +191,9 @@ drive_find <- function(
     n = function(x) length(x$files)
   )
 
-  res_tbl <- proc_res_list %>%
-    map("files") %>%
-    purrr::flatten() %>%
+  res_tbl <- proc_res_list |>
+    map("files") |>
+    purrr::flatten() |>
     as_dribble()
 
   # there is some evidence of overlap in the results returned in different

--- a/R/drive_get.R
+++ b/R/drive_get.R
@@ -67,7 +67,7 @@
 #' drive_get("~/")
 #' # the API reserves the file id "root" for your root folder
 #' drive_get(id = "root")
-#' drive_get(id = "root") %>% drive_reveal("path")
+#' drive_get(id = "root") |> drive_reveal("path")
 #'
 #' # set up some files to get by path
 #' alfalfa <- drive_mkdir("alfalfa")

--- a/R/drive_get_path.R
+++ b/R/drive_get_path.R
@@ -139,9 +139,9 @@ resolve_paths <- function(d, folders = dribble()) {
 
 # converts files in a dribble to the form used in pth()
 pthize <- function(d) {
-  d <- d %>%
-    drive_reveal("mime_type") %>%
-    drive_reveal("parent") %>%
+  d <- d |>
+    drive_reveal("mime_type") |>
+    drive_reveal("parent") |>
     drive_reveal("shortcut_details")
   purrr::transpose(
     d[c(

--- a/R/drive_mv.R
+++ b/R/drive_mv.R
@@ -22,7 +22,7 @@
 #' @export
 #' @examplesIf drive_has_token()
 #' # create a file to move
-#' file <- drive_example_remote("chicken.txt") %>%
+#' file <- drive_example_remote("chicken.txt") |>
 #'   drive_cp("chicken-mv.txt")
 #'
 #' # rename it, but leave in current folder (root folder, in this case)

--- a/R/drive_publish.R
+++ b/R/drive_publish.R
@@ -20,7 +20,7 @@
 #' @export
 #' @examplesIf drive_has_token()
 #' # Create a file to publish
-#' file <- drive_example_remote("chicken_sheet") %>%
+#' file <- drive_example_remote("chicken_sheet") |>
 #'   drive_cp()
 #'
 #' # Publish file

--- a/R/drive_put.R
+++ b/R/drive_put.R
@@ -46,7 +46,7 @@
 #' drive_put(local_file)
 #'
 #' # Clean up
-#' drive_find("drive_put_.+[.]txt") %>% drive_rm()
+#' drive_find("drive_put_.+[.]txt") |> drive_rm()
 #' unlink(local_file)
 drive_put <- function(
   media,

--- a/R/drive_read.R
+++ b/R/drive_read.R
@@ -25,17 +25,17 @@
 #' @examplesIf drive_has_token()
 #' # comma-separated values --> data.frame or tibble
 #' (chicken_csv <- drive_example_remote("chicken.csv"))
-#' chicken_csv %>%
-#'   drive_read_string() %>%
+#' chicken_csv |>
+#'   drive_read_string() |>
 #'   read.csv(text = .)
 #'
 #' # Google Doc --> character vector
 #' (chicken_doc <- drive_example_remote("chicken_doc"))
-#' chicken_doc %>%
+#' chicken_doc |>
 #'   # NOTE: we must specify an export MIME type
-#'   drive_read_string(type = "text/plain") %>%
-#'   strsplit(split = "(\r\n|\r|\n)") %>%
-#'   .[[1]]
+#'   drive_read_string(type = "text/plain") |>
+#'   strsplit(split = "(\r\n|\r|\n)") |>
+#'   (\(.) .[[1]])()
 drive_read_string <- function(file, type = NULL, encoding = NULL) {
   drive_read_impl(file = file, type = type, as = "string", encoding = encoding)
 }

--- a/R/drive_reveal.R
+++ b/R/drive_reveal.R
@@ -128,7 +128,7 @@
 #' drive_reveal(files, "quota_bytes_used")
 #'
 #' # 'root' is a special file id that represents your My Drive root folder
-#' drive_get(id = "root") %>%
+#' drive_get(id = "root") |>
 #'   drive_reveal("path")
 drive_reveal <- function(
   file,

--- a/R/drive_rm.R
+++ b/R/drive_rm.R
@@ -20,15 +20,15 @@
 #' (src_file <- drive_example_remote("chicken.txt"))
 #'
 #' # Create a copy, then remove it by name
-#' src_file %>%
+#' src_file |>
 #'   drive_cp(name = "chicken-rm.txt")
 #' drive_rm("chicken-rm.txt")
 #'
 #' # Create several more copies
-#' x1 <- src_file %>%
+#' x1 <- src_file |>
 #'   drive_cp(name = "chicken-abc.txt")
 #' drive_cp(src_file, name = "chicken-def.txt")
-#' x2 <- src_file %>%
+#' x2 <- src_file |>
 #'   drive_cp(name = "chicken-ghi.txt")
 #'
 #' # Remove the copies all at once, specified in different ways

--- a/R/drive_share.R
+++ b/R/drive_share.R
@@ -39,11 +39,11 @@
 #' @export
 #' @examplesIf drive_has_token()
 #' # Create a file to share
-#' file <- drive_example_remote("chicken_doc") %>%
+#' file <- drive_example_remote("chicken_doc") |>
 #'   drive_cp(name = "chicken-share.txt")
 #'
 #' # Let a specific person comment
-#' file <- file %>%
+#' file <- file |>
 #'   drive_share(
 #'     role = "commenter",
 #'     type = "user",
@@ -51,7 +51,7 @@
 #'   )
 #'
 #' # Let a different specific person edit and customize the email notification
-#' file <- file %>%
+#' file <- file |>
 #'   drive_share(
 #'     role = "writer",
 #'     type = "user",
@@ -60,7 +60,7 @@
 #'   )
 #'
 #' # Let anyone read the file
-#' file <- file %>%
+#' file <- file |>
 #'   drive_share(role = "reader", type = "anyone")
 #' # Single-purpose wrapper function for this
 #' drive_share_anyone(file)

--- a/R/drive_trash.R
+++ b/R/drive_trash.R
@@ -6,7 +6,7 @@
 #' @export
 #' @examplesIf drive_has_token()
 #' # Create a file and put it in the trash.
-#' file <- drive_example_remote("chicken.txt") %>%
+#' file <- drive_example_remote("chicken.txt") |>
 #'   drive_cp("chicken-trash.txt")
 #' drive_trash("chicken-trash.txt")
 #'

--- a/R/drive_update.R
+++ b/R/drive_update.R
@@ -20,21 +20,21 @@
 #'
 #' @examplesIf drive_has_token()
 #' # Create a new file, so we can update it
-#' x <- drive_example_remote("chicken.csv") %>%
+#' x <- drive_example_remote("chicken.csv") |>
 #'   drive_cp()
 #'
 #' # Update the file with new media
-#' x <- x %>%
+#' x <- x |>
 #'   drive_update(drive_example_local("chicken.txt"))
 #'
 #' # Update the file with new metadata.
 #' # Notice here `name` is not an argument of `drive_update()`, we are passing
 #' # this to the API via the `...``
-#' x <- x %>%
+#' x <- x |>
 #'   drive_update(name = "CHICKENS!")
 #'
 #' # Update the file with new media AND new metadata
-#' x <- x %>%
+#' x <- x |>
 #'   drive_update(
 #'     drive_example_local("chicken.txt"),
 #'     name = "chicken-poem-again.txt"

--- a/R/drive_upload.R
+++ b/R/drive_upload.R
@@ -34,11 +34,11 @@
 #' @export
 #' @examplesIf drive_has_token()
 #' # upload a csv file
-#' chicken_csv <- drive_example_local("chicken.csv") %>%
+#' chicken_csv <- drive_example_local("chicken.csv") |>
 #'   drive_upload("chicken-upload.csv")
 #'
 #' # or convert it to a Google Sheet
-#' chicken_sheet <- drive_example_local("chicken.csv") %>%
+#' chicken_sheet <- drive_example_local("chicken.csv") |>
 #'   drive_upload(
 #'     name = "chicken-sheet-upload.csv",
 #'     type = "spreadsheet"
@@ -48,10 +48,10 @@
 #' drive_browse(chicken_sheet)
 #'
 #' # Clean up
-#' drive_find("chicken.*upload") %>% drive_rm()
+#' drive_find("chicken.*upload") |> drive_rm()
 #'
 #' # Upload a file and, at the same time, star it
-#' chicken <- drive_example_local("chicken.jpg") %>%
+#' chicken <- drive_example_local("chicken.jpg") |>
 #'   drive_upload(starred = "true")
 #'
 #' # Is is really starred? YES
@@ -63,14 +63,14 @@
 #' # `overwrite = FALSE` errors if something already exists at target filepath
 #' # THIS WILL ERROR!
 #' drive_create("name-squatter-upload")
-#' drive_example_local("chicken.jpg") %>%
+#' drive_example_local("chicken.jpg") |>
 #'   drive_upload(
 #'     name = "name-squatter-upload",
 #'     overwrite = FALSE
 #'   )
 #'
 #' # `overwrite = TRUE` moves the existing item to trash, then proceeds
-#' chicken <- drive_example_local("chicken.jpg") %>%
+#' chicken <- drive_example_local("chicken.jpg") |>
 #'   drive_upload(
 #'     name = "name-squatter-upload",
 #'     overwrite = TRUE

--- a/R/googledrive-package.R
+++ b/R/googledrive-package.R
@@ -17,7 +17,7 @@
 #'   give people what they want (file name), track what the API wants (file id),
 #'   and to hold the metadata needed for general file operations.
 #'
-#'   googledrive is "pipe-friendly" and, in fact, re-exports `%>%`, but does not
+#'   googledrive is "pipe-friendly" and, in fact, re-exports `|>`, but does not
 #'   require its use.
 #'
 #'   Please see the googledrive website for full documentation:

--- a/R/shared_drive_find.R
+++ b/R/shared_drive_find.R
@@ -38,9 +38,9 @@ shared_drive_find <- function(pattern = NULL, n_max = Inf, ...) {
     n = function(x) length(x$drives)
   )
 
-  res_tbl <- proc_res_list %>%
-    map("drives") %>%
-    purrr::flatten() %>%
+  res_tbl <- proc_res_list |>
+    map("drives") |>
+    purrr::flatten() |>
     as_dribble()
 
   if (!is.null(pattern)) {

--- a/R/shortcut.R
+++ b/R/shortcut.R
@@ -35,19 +35,19 @@
 #' # This shortcut could now be moved, renamed, etc.
 #'
 #' # Create a shortcut in the default location with a custom name
-#' sc2 <- src_file %>%
+#' sc2 <- src_file |>
 #'   shortcut_create(name = "chicken_sheet_second_shortcut")
 #'
 #' # Create a folder, then put a shortcut there, with default name
 #' folder <- drive_mkdir("chicken_sheet_shortcut_folder")
-#' sc3 <- src_file %>%
+#' sc3 <- src_file |>
 #'   shortcut_create(folder)
 #'
 #' # Look at all these shortcuts
 #' (dat <- drive_find("chicken_sheet", type = "shortcut"))
 #'
 #' # Confirm the shortcuts all target the original file
-#' dat <- dat %>%
+#' dat <- dat |>
 #'   drive_reveal("shortcut_details")
 #' purrr::map_chr(dat$shortcut_details, "targetId")
 #' as_id(src_file)
@@ -102,15 +102,15 @@ shortcut_create <- function(file, path = NULL, name = NULL, overwrite = NA) {
 #'
 #' @examplesIf drive_has_token()
 #' # Create a file to make a shortcut to
-#' file <- drive_example_remote("chicken_sheet") %>%
+#' file <- drive_example_remote("chicken_sheet") |>
 #'   drive_cp(name = "chicken-sheet-for-shortcut")
 #'
 #' # Create a shortcut
-#' sc1 <- file %>%
+#' sc1 <- file |>
 #'   shortcut_create(name = "shortcut-1")
 #'
 #' # Create a second shortcut by copying the first
-#' sc1 <- sc1 %>%
+#' sc1 <- sc1 |>
 #'   drive_cp(name = "shortcut-2")
 #'
 #' # Get the shortcuts
@@ -174,9 +174,9 @@ resolve_one <- function(name, id, drive_resource, ...) {
   target_id <- pluck(drive_resource, "shortcutDetails", "targetId")
   if (is_null(target_id)) {
     return(
-      list(drive_resource) %>%
-        as_dribble() %>%
-        put_column(nm = "id_shortcut", val = NA_character_, .after = "id") %>%
+      list(drive_resource) |>
+        as_dribble() |>
+        put_column(nm = "id_shortcut", val = NA_character_, .after = "id") |>
         put_column(nm = "name_shortcut", val = NA_character_, .after = "id")
     )
   }
@@ -190,8 +190,8 @@ resolve_one <- function(name, id, drive_resource, ...) {
       }
     }
   )
-  out %>%
-    put_column(nm = "id_shortcut", val = id, .after = "id") %>%
+  out |>
+    put_column(nm = "id_shortcut", val = id, .after = "id") |>
     put_column(nm = "name_shortcut", val = name, .after = "id")
 }
 

--- a/data-raw/discovery-doc-ingest.R
+++ b/data-raw/discovery-doc-ingest.R
@@ -32,9 +32,9 @@ dd <- read_discovery_document(x)
 
 methods <- get_raw_methods(dd)
 
-methods <- methods %>% map(groom_properties, dd)
-methods <- methods %>% map(add_schema_params, dd)
-methods <- methods %>% map(add_global_params, dd)
+methods <- methods |> map(groom_properties, dd)
+methods <- methods |> map(add_schema_params, dd)
+methods <- methods |> map(add_global_params, dd)
 
 ## duplicate two methods to create a companion for media
 ## simpler to do this here, in data, than in wrapper functions

--- a/data-raw/drive-examples-inventory.R
+++ b/data-raw/drive-examples-inventory.R
@@ -19,9 +19,9 @@ if (anyDuplicated(dat$name)) {
   stop("Duplicated file names! You are making a huge mistake.")
 }
 
-dat <- dat %>%
-  drive_reveal("mime_type") %>%
-  select(name, mime_type, id) %>%
+dat <- dat |>
+  drive_reveal("mime_type") |>
+  select(name, mime_type, id) |>
   arrange(name, mime_type)
 
 # record in local csv, because the visibility afforded by a plain old csv file
@@ -32,7 +32,7 @@ write_csv(
 )
 
 # keep just (name, id) for the official lookup Sheet
-dat2 <- dat %>%
+dat2 <- dat |>
   select(name, id)
 dat2
 

--- a/data-raw/mime-types.R
+++ b/data-raw/mime-types.R
@@ -16,22 +16,22 @@ googledrive:::drive_auth_testing()
 about <- drive_about()
 fmts <- about[c("importFormats", "exportFormats")]
 
-imports <- fmts %>%
-  pluck("importFormats") %>%
+imports <- fmts |>
+  pluck("importFormats") |>
   enframe(
     name = "mime_type_local",
     value = "mime_type_google"
-  ) %>%
-  unnest_longer(mime_type_google) %>%
+  ) |>
+  unnest_longer(mime_type_google) |>
   mutate(action = "import")
 
-exports <- fmts %>%
-  pluck("exportFormats") %>%
+exports <- fmts |>
+  pluck("exportFormats") |>
   enframe(
     name = "mime_type_google",
     value = "mime_type_local"
-  ) %>%
-  unnest_longer(mime_type_local) %>%
+  ) |>
+  unnest_longer(mime_type_local) |>
   mutate(action = "export")
 
 translate_mime_types <- bind_rows(imports, exports)
@@ -39,15 +39,15 @@ translate_mime_types <- bind_rows(imports, exports)
 # where did this csv come from? these must be my decisions, because the
 # drive.files.export endpoint has `mimeType` as a required query parameter, i.e.
 # I see no basis for saying that the Drive API has default export MIME types
-defaults <- here("data-raw", "export-mime-type-defaults.csv") %>%
-  read_csv() %>%
+defaults <- here("data-raw", "export-mime-type-defaults.csv") |>
+  read_csv() |>
   mutate(
     action = "export",
     default = TRUE
   )
 
-translate_mime_types <- translate_mime_types %>%
-  left_join(defaults) %>%
+translate_mime_types <- translate_mime_types |>
+  left_join(defaults) |>
   mutate(
     default = case_when(
       action == "import" ~ NA,
@@ -58,8 +58,8 @@ translate_mime_types <- translate_mime_types %>%
 
 # be intentional about row order so diffs are easier to make sense of
 # I think it also makes sense to set column order accordingly
-translate_mime_types <- translate_mime_types %>%
-  arrange(action, mime_type_google, mime_type_local) %>%
+translate_mime_types <- translate_mime_types |>
+  arrange(action, mime_type_google, mime_type_local) |>
   select(action, mime_type_google, everything())
 
 write_csv(
@@ -73,32 +73,32 @@ write_csv(
 # Google Drive
 url <- "https://developers.google.com/drive/api/v3/mime-types"
 
-google_mime_types <- GET(url) %>%
-  content() %>%
-  html_table(fill = TRUE) %>%
-  flatten() %>%
-  as_tibble() %>%
+google_mime_types <- GET(url) |>
+  content() |>
+  html_table(fill = TRUE) |>
+  flatten() |>
+  as_tibble() |>
   select(
     mime_type = `MIME Type`,
     description = Description
-  ) %>%
+  ) |>
   mutate(description = na_if(description, ""))
 
-mime_tbl <- translate_mime_types %>%
-  select(mime_type = mime_type_local) %>%
-  distinct() %>%
+mime_tbl <- translate_mime_types |>
+  select(mime_type = mime_type_local) |>
+  distinct() |>
   bind_rows(google_mime_types)
 
 # use mime::mimemap map extensions
-mime_ext <- mime::mimemap %>%
-  enframe(name = "ext", value = "mime_type") %>%
+mime_ext <- mime::mimemap |>
+  enframe(name = "ext", value = "mime_type") |>
   select(mime_type, ext)
 
-mime_tbl <- mime_ext %>%
+mime_tbl <- mime_ext |>
   right_join(mime_tbl, by = "mime_type")
 
 google_prefix <- "application/vnd.google-apps."
-mime_tbl <- mime_tbl %>%
+mime_tbl <- mime_tbl |>
   mutate(
     human_type = ifelse(
       grepl(google_prefix, mime_type, fixed = TRUE),
@@ -108,12 +108,12 @@ mime_tbl <- mime_tbl %>%
   )
 
 # where did this csv come from? these must be my choices
-default_ext <- here("data-raw", "extension-mime-type-defaults.csv") %>%
-  read_csv() %>%
+default_ext <- here("data-raw", "extension-mime-type-defaults.csv") |>
+  read_csv() |>
   mutate(default = TRUE)
 
-mime_tbl <- mime_tbl %>%
-  left_join(default_ext) %>%
+mime_tbl <- mime_tbl |>
+  left_join(default_ext) |>
   mutate(
     default = case_when(
       is.na(ext) ~ NA,
@@ -122,7 +122,7 @@ mime_tbl <- mime_tbl %>%
     )
   )
 
-mime_tbl <- mime_tbl %>%
+mime_tbl <- mime_tbl |>
   add_row(
     # TODO(jennybc): consider also "application/vnd.google.colaboratory"
     mime_type = "application/vnd.google.colab",
@@ -132,7 +132,7 @@ mime_tbl <- mime_tbl %>%
     default = TRUE
   )
 
-mime_tbl <- mime_tbl %>%
+mime_tbl <- mime_tbl |>
   arrange(mime_type, ext)
 
 write_csv(mime_tbl, file = here("inst", "extdata", "data", "mime_tbl.csv"))

--- a/index.Rmd
+++ b/index.Rmd
@@ -88,7 +88,7 @@ if (isTRUE(SETUP)) {
     path = abc_def,
     name = "googledrive-NEWS.md"
   )
-  
+
   THANKS <- drive_get("THANKS")
   r_logo <- drive_get("r_logo.jpg")
   x <- list(THANKS, r_logo)
@@ -112,7 +112,7 @@ if (isTRUE(CLEAN)) {
   - Give humans what they want: the file name
   - Track what the API wants: the file ID
   - Hold on to all the other metadata sent back by the API
-* googledrive is "pipe-friendly" and, in fact, re-exports `%>%`, but does not require its use.
+* googledrive is "pipe-friendly" and, in fact, re-exports `|>`, but does not require its use.
 
 ### Quick demo
 
@@ -148,7 +148,7 @@ You generally want to store the result of a googledrive call, as we do with `fil
 ```
 
 `as_id()` can be used to convert various inputs into a marked vector of file ids. It works on file ids (for obvious reasons!), various forms of Drive URLs, and `dribble`s.
- 
+
 ```{r}
 x$id
 
@@ -161,7 +161,7 @@ In general, googledrive functions that operate on files allow you to specify the
 
 #### Upload files
 
-We can upload any file type. 
+We can upload any file type.
 
 ```{r}
 (chicken <- drive_upload(
@@ -176,7 +176,7 @@ Notice that file was uploaded as `text/csv`. Since this was a `.csv` document, a
 drive_rm(chicken)
 
 # example of using a dribble as input
-chicken_sheet <- drive_example_local("chicken.csv") %>% 
+chicken_sheet <- drive_example_local("chicken.csv") |>
   drive_upload(
     name = "index-chicken-sheet",
     type = "spreadsheet"
@@ -190,14 +190,14 @@ Much better!
 To allow other people to access your file, you need to change the sharing permissions. You can check the sharing status by running `drive_reveal(..., "permissions")`, which adds a logical column `shared` and parks more detailed metadata in a `permissions_resource` variable.
 
 ```{r}
-chicken_sheet %>% 
+chicken_sheet |>
   drive_reveal("permissions")
 ```
 
 Here's how to grant anyone with the link permission to view this data set.
 
 ```{r}
-(chicken_sheet <- chicken_sheet %>%
+(chicken_sheet <- chicken_sheet |>
    drive_share(role = "reader", type = "anyone"))
 ```
 
@@ -208,7 +208,7 @@ This comes up so often, there's even a convenience wrapper, `drive_share_anyone(
 Versions of Google Documents, Sheets, and Presentations can be published online. You can check your publication status by running `drive_reveal(..., "published")`, which adds a logical column `published` and parks more detailed metadata in a `revision_resource` variable.
 
 ```{r}
-chicken_sheet %>% 
+chicken_sheet |>
   drive_reveal("published")
 ```
 
@@ -253,7 +253,7 @@ Downloading files that are *not* Google type files is even simpler, i.e. it does
 ```{r}
 # download it and prove we got it
 drive_download("chicken.txt")
-readLines("chicken.txt") %>% head()
+readLines("chicken.txt") |> head()
 ```
 
 #### Clean up
@@ -262,7 +262,7 @@ readLines("chicken.txt") %>% head()
 file.remove(c(
   "index-chicken-sheet.csv", "index-chicken-sheet.xlsx", "chicken.txt"
 ))
-drive_find("index-chicken") %>% drive_rm()
+drive_find("index-chicken") |> drive_rm()
 ```
 
 ## Privacy

--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ library("googledrive")
   - Give humans what they want: the file name
   - Track what the API wants: the file ID
   - Hold on to all the other metadata sent back by the API
-- googledrive is “pipe-friendly” and, in fact, re-exports `%>%`, but
+- googledrive is “pipe-friendly” and, in fact, re-exports `|>`, but
   does not require its use.
 
 ### Quick demo
@@ -57,17 +57,17 @@ package to deal on your behalf with Google Drive.
 drive_find(n_max = 30)
 #> # A dribble: 30 × 3
 #>    name                       id                                drive_resource
-#>    <chr>                      <drv_id>                          <list>        
-#>  1 2021-09-16_r_logo.jpg      1dandXB0QZpjeGQq_56wTXKNwaqgsOa9D <named list>  
-#>  2 2021-09-16_r_about.html    1XfCI_orH4oNUZh06C4w6vXtno-BT_zmZ <named list>  
-#>  3 2021-09-16_imdb_latin1.csv 163YPvqYmGuqQiEwEFLg2s1URq4EnpkBw <named list>  
-#>  4 2021-09-16_chicken.txt     1axJz8GSmecSnaYBx0Sb3Gb-SXVaTzKw7 <named list>  
-#>  5 2021-09-16_chicken.pdf     14Hd6_VQAeEgcwBBJamc-FUlnXhp117T2 <named list>  
-#>  6 2021-09-16_chicken.jpg     1aslW1T-B8UKzAEotDWpmRFaMyMux5-it <named list>  
-#>  7 2021-09-16_chicken.csv     1Mj--zJYZJSMKsNVjk2tYFef5LnCsNoDT <named list>  
-#>  8 pqr                        143iq-CswFTwJTjVfKkcFMDW0jYqDeUj2 <named list>  
-#>  9 mno                        1gcUTnFbsF6uioJrLCsVQ78_F1wEzyNtI <named list>  
-#> 10 jkl                        17T40phn99w0hY-B_Ev0deTvVg9fmUSnt <named list>  
+#>    <chr>                      <drv_id>                          <list>
+#>  1 2021-09-16_r_logo.jpg      1dandXB0QZpjeGQq_56wTXKNwaqgsOa9D <named list>
+#>  2 2021-09-16_r_about.html    1XfCI_orH4oNUZh06C4w6vXtno-BT_zmZ <named list>
+#>  3 2021-09-16_imdb_latin1.csv 163YPvqYmGuqQiEwEFLg2s1URq4EnpkBw <named list>
+#>  4 2021-09-16_chicken.txt     1axJz8GSmecSnaYBx0Sb3Gb-SXVaTzKw7 <named list>
+#>  5 2021-09-16_chicken.pdf     14Hd6_VQAeEgcwBBJamc-FUlnXhp117T2 <named list>
+#>  6 2021-09-16_chicken.jpg     1aslW1T-B8UKzAEotDWpmRFaMyMux5-it <named list>
+#>  7 2021-09-16_chicken.csv     1Mj--zJYZJSMKsNVjk2tYFef5LnCsNoDT <named list>
+#>  8 pqr                        143iq-CswFTwJTjVfKkcFMDW0jYqDeUj2 <named list>
+#>  9 mno                        1gcUTnFbsF6uioJrLCsVQ78_F1wEzyNtI <named list>
+#> 10 jkl                        17T40phn99w0hY-B_Ev0deTvVg9fmUSnt <named list>
 #> # ℹ 20 more rows
 ```
 
@@ -92,8 +92,8 @@ by “anyone with a link”, do this:
 ``` r
 (files <- drive_find(q = c("starred = true", "visibility = 'anyoneWithLink'")))
 #> # A dribble: 2 × 3
-#>   name       id                                drive_resource   
-#>   <chr>      <drv_id>                          <list>           
+#>   name       id                                drive_resource
+#>   <chr>      <drv_id>                          <list>
 #> 1 r_logo.jpg 1wFAZdmBiSRu4GShsqurxD7wIDSCZvPud <named list [43]>
 #> 2 THANKS     19URV7BT0_E1KhYdfDODszK5aiELOwTSz <named list [42]>
 ```
@@ -112,8 +112,8 @@ files by name (path, really) or by Drive file id using `drive_get()`.
 (x <- drive_get("~/abc/def/googledrive-NEWS.md"))
 #> ✔ The input `path` resolved to exactly 1 file.
 #> # A dribble: 1 × 4
-#>   name                path                          id       drive_resource   
-#>   <chr>               <chr>                         <drv_id> <list>           
+#>   name                path                          id       drive_resource
+#>   <chr>               <chr>                         <drv_id> <list>
 #> 1 googledrive-NEWS.md ~/abc/def/googledrive-NEWS.md 1h1lhFf… <named list [41]>
 ```
 
@@ -129,13 +129,13 @@ x$id
 # let's retrieve same file by id (also a great way to force-refresh metadata)
 drive_get(x$id)
 #> # A dribble: 1 × 3
-#>   name                id                                drive_resource   
-#>   <chr>               <drv_id>                          <list>           
+#>   name                id                                drive_resource
+#>   <chr>               <drv_id>                          <list>
 #> 1 googledrive-NEWS.md 1h1lhFfQrDZevE2OEX10-rbi2BfvGogFm <named list [41]>
 drive_get(as_id(x))
 #> # A dribble: 1 × 3
-#>   name                id                                drive_resource   
-#>   <chr>               <drv_id>                          <list>           
+#>   name                id                                drive_resource
+#>   <chr>               <drv_id>                          <list>
 #> 1 googledrive-NEWS.md 1h1lhFfQrDZevE2OEX10-rbi2BfvGogFm <named list [41]>
 ```
 
@@ -161,8 +161,8 @@ We can upload any file type.
 #> With MIME type:
 #> • 'text/csv'
 #> # A dribble: 1 × 3
-#>   name              id                                drive_resource   
-#>   <chr>             <drv_id>                          <list>           
+#>   name              id                                drive_resource
+#>   <chr>             <drv_id>                          <list>
 #> 1 index-chicken.csv 1dE2U3TUvYulwE88ucBPQHP0-CB4zEK7P <named list [41]>
 ```
 
@@ -177,7 +177,7 @@ drive_rm(chicken)
 #> • 'index-chicken.csv' <id: 1dE2U3TUvYulwE88ucBPQHP0-CB4zEK7P>
 
 # example of using a dribble as input
-chicken_sheet <- drive_example_local("chicken.csv") %>% 
+chicken_sheet <- drive_example_local("chicken.csv") |>
   drive_upload(
     name = "index-chicken-sheet",
     type = "spreadsheet"
@@ -200,11 +200,11 @@ sharing permissions. You can check the sharing status by running
 and parks more detailed metadata in a `permissions_resource` variable.
 
 ``` r
-chicken_sheet %>% 
+chicken_sheet |>
   drive_reveal("permissions")
 #> # A dribble: 1 × 5
 #>   name                shared id       drive_resource    permissions_resource
-#>   <chr>               <lgl>  <drv_id> <list>            <list>              
+#>   <chr>               <lgl>  <drv_id> <list>            <list>
 #> 1 index-chicken-sheet FALSE  1KXgDfk… <named list [36]> <named list [2]>
 ```
 
@@ -212,7 +212,7 @@ Here’s how to grant anyone with the link permission to view this data
 set.
 
 ``` r
-(chicken_sheet <- chicken_sheet %>%
+(chicken_sheet <- chicken_sheet |>
    drive_share(role = "reader", type = "anyone"))
 #> Permissions updated:
 #> • role = reader
@@ -221,7 +221,7 @@ set.
 #> • 'index-chicken-sheet' <id: 1KXgDfk3IfJg833XokFhKDahY9aDml-183NHPz3qXlAY>
 #> # A dribble: 1 × 5
 #>   name                shared id       drive_resource    permissions_resource
-#>   <chr>               <lgl>  <drv_id> <list>            <list>              
+#>   <chr>               <lgl>  <drv_id> <list>            <list>
 #> 1 index-chicken-sheet TRUE   1KXgDfk… <named list [37]> <named list [2]>
 ```
 
@@ -237,12 +237,12 @@ online. You can check your publication status by running
 variable.
 
 ``` r
-chicken_sheet %>% 
+chicken_sheet |>
   drive_reveal("published")
 #> # A dribble: 1 × 7
 #>   name             published shared id       drive_resource permissions_resource
-#>   <chr>            <lgl>     <lgl>  <drv_id> <list>         <list>              
-#> 1 index-chicken-s… FALSE     TRUE   1KXgDfk… <named list>   <named list [2]>    
+#>   <chr>            <lgl>     <lgl>  <drv_id> <list>         <list>
+#> 1 index-chicken-s… FALSE     TRUE   1KXgDfk… <named list>   <named list [2]>
 #> # ℹ 1 more variable: revision_resource <list>
 ```
 
@@ -254,8 +254,8 @@ By default, `drive_publish()` will publish your most recent version.
 #> • 'index-chicken-sheet' <id: 1KXgDfk3IfJg833XokFhKDahY9aDml-183NHPz3qXlAY>
 #> # A dribble: 1 × 7
 #>   name             published shared id       drive_resource permissions_resource
-#>   <chr>            <lgl>     <lgl>  <drv_id> <list>         <list>              
-#> 1 index-chicken-s… TRUE      TRUE   1KXgDfk… <named list>   <named list [2]>    
+#>   <chr>            <lgl>     <lgl>  <drv_id> <list>         <list>
+#> 1 index-chicken-s… TRUE      TRUE   1KXgDfk… <named list>   <named list [2]>
 #> # ℹ 1 more variable: revision_resource <list>
 ```
 
@@ -318,12 +318,12 @@ drive_download("chicken.txt")
 #> • 'chicken.txt' <id: 1xMvlJHia_qYNZmucaStDcOF9A9PD4BOT>
 #> Saved locally as:
 #> • 'chicken.txt'
-readLines("chicken.txt") %>% head()
-#> [1] "A chicken whose name was Chantecler"      
-#> [2] "Clucked in iambic pentameter"             
+readLines("chicken.txt") |> head()
+#> [1] "A chicken whose name was Chantecler"
+#> [2] "Clucked in iambic pentameter"
 #> [3] "It sat on a shelf, reading Song of Myself"
-#> [4] "And laid eggs with a perfect diameter."   
-#> [5] ""                                         
+#> [4] "And laid eggs with a perfect diameter."
+#> [5] ""
 #> [6] "—Richard Maxson"
 ```
 
@@ -334,7 +334,7 @@ file.remove(c(
   "index-chicken-sheet.csv", "index-chicken-sheet.xlsx", "chicken.txt"
 ))
 #> [1] TRUE TRUE TRUE
-drive_find("index-chicken") %>% drive_rm()
+drive_find("index-chicken") |> drive_rm()
 #> File deleted:
 #> • 'index-chicken-sheet' <id: 1KXgDfk3IfJg833XokFhKDahY9aDml-183NHPz3qXlAY>
 ```

--- a/man/as_dribble.Rd
+++ b/man/as_dribble.Rd
@@ -57,6 +57,6 @@ as_dribble(c("alfa", "alfa/bravo"))
 # as_dribble(as_id("0B0Gh-SuuA2nTOGZVTXZTREgwZ2M"))
 
 # Clean up
-drive_find("alfa") \%>\% drive_rm()
+drive_find("alfa") |> drive_rm()
 \dontshow{\}) # examplesIf}
 }

--- a/man/drive_about.Rd
+++ b/man/drive_about.Rd
@@ -21,7 +21,7 @@ drive_about()
 
 # explore the export formats available for Drive files, by MIME type
 about <- drive_about()
-about[["exportFormats"]] \%>\%
+about[["exportFormats"]] |>
   purrr::map(unlist)
 \dontshow{\}) # examplesIf}
 }

--- a/man/drive_browse.Rd
+++ b/man/drive_browse.Rd
@@ -19,6 +19,6 @@ Visits a file on Google Drive in your default browser.
 }
 \examples{
 \dontshow{if (drive_has_token() && rlang::is_interactive()) withAutoprint(\{ # examplesIf}
-drive_find(n_max = 1) \%>\% drive_browse()
+drive_find(n_max = 1) |> drive_browse()
 \dontshow{\}) # examplesIf}
 }

--- a/man/drive_examples.Rd
+++ b/man/drive_examples.Rd
@@ -38,8 +38,8 @@ the example files. See \code{vignette("example-files", package = "googledrive")}
 for more.
 }
 \examples{
-drive_examples_local() \%>\% basename()
-drive_examples_local("chicken") \%>\% basename()
+drive_examples_local() |> basename()
+drive_examples_local("chicken") |> basename()
 drive_example_local("imdb")
 
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}

--- a/man/drive_get.Rd
+++ b/man/drive_get.Rd
@@ -95,7 +95,7 @@ search other collections of items. Read more about \link[=shared_drives]{shared 
 drive_get("~/")
 # the API reserves the file id "root" for your root folder
 drive_get(id = "root")
-drive_get(id = "root") \%>\% drive_reveal("path")
+drive_get(id = "root") |> drive_reveal("path")
 
 # set up some files to get by path
 alfalfa <- drive_mkdir("alfalfa")

--- a/man/drive_mv.Rd
+++ b/man/drive_mv.Rd
@@ -67,7 +67,7 @@ Move a Drive file to a different folder, give it a different name, or both.
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # create a file to move
-file <- drive_example_remote("chicken.txt") \%>\%
+file <- drive_example_remote("chicken.txt") |>
   drive_cp("chicken-mv.txt")
 
 # rename it, but leave in current folder (root folder, in this case)

--- a/man/drive_publish.Rd
+++ b/man/drive_publish.Rd
@@ -40,7 +40,7 @@ Read more in \code{\link[=drive_reveal]{drive_reveal()}}.
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # Create a file to publish
-file <- drive_example_remote("chicken_sheet") \%>\%
+file <- drive_example_remote("chicken_sheet") |>
   drive_cp()
 
 # Publish file

--- a/man/drive_put.Rd
+++ b/man/drive_put.Rd
@@ -98,7 +98,7 @@ file2 <- drive_create(basename(local_file))
 drive_put(local_file)
 
 # Clean up
-drive_find("drive_put_.+[.]txt") \%>\% drive_rm()
+drive_find("drive_put_.+[.]txt") |> drive_rm()
 unlink(local_file)
 \dontshow{\}) # examplesIf}
 }

--- a/man/drive_read_string.Rd
+++ b/man/drive_read_string.Rd
@@ -45,16 +45,16 @@ for \code{\link[=drive_download]{drive_download()}} for more.
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # comma-separated values --> data.frame or tibble
 (chicken_csv <- drive_example_remote("chicken.csv"))
-chicken_csv \%>\%
-  drive_read_string() \%>\%
+chicken_csv |>
+  drive_read_string() |>
   read.csv(text = .)
 
 # Google Doc --> character vector
 (chicken_doc <- drive_example_remote("chicken_doc"))
-chicken_doc \%>\%
+chicken_doc |>
   # NOTE: we must specify an export MIME type
-  drive_read_string(type = "text/plain") \%>\%
-  strsplit(split = "(\r\n|\r|\n)") \%>\%
-  .[[1]]
+  drive_read_string(type = "text/plain") |>
+  strsplit(split = "(\r\n|\r|\n)") |>
+  (\(.) .[[1]])()
 \dontshow{\}) # examplesIf}
 }

--- a/man/drive_reveal.Rd
+++ b/man/drive_reveal.Rd
@@ -139,7 +139,7 @@ drive_reveal(files, "size")
 drive_reveal(files, "quota_bytes_used")
 
 # 'root' is a special file id that represents your My Drive root folder
-drive_get(id = "root") \%>\%
+drive_get(id = "root") |>
   drive_reveal("path")
 \dontshow{\}) # examplesIf}
 }

--- a/man/drive_rm.Rd
+++ b/man/drive_rm.Rd
@@ -32,15 +32,15 @@ option, see \code{\link[=drive_trash]{drive_trash()}}.
 (src_file <- drive_example_remote("chicken.txt"))
 
 # Create a copy, then remove it by name
-src_file \%>\%
+src_file |>
   drive_cp(name = "chicken-rm.txt")
 drive_rm("chicken-rm.txt")
 
 # Create several more copies
-x1 <- src_file \%>\%
+x1 <- src_file |>
   drive_cp(name = "chicken-abc.txt")
 drive_cp(src_file, name = "chicken-def.txt")
-x2 <- src_file \%>\%
+x2 <- src_file |>
   drive_cp(name = "chicken-ghi.txt")
 
 # Remove the copies all at once, specified in different ways

--- a/man/drive_share.Rd
+++ b/man/drive_share.Rd
@@ -66,11 +66,11 @@ read, comment, or edit. The returned \code{\link{dribble}} will have extra colum
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # Create a file to share
-file <- drive_example_remote("chicken_doc") \%>\%
+file <- drive_example_remote("chicken_doc") |>
   drive_cp(name = "chicken-share.txt")
 
 # Let a specific person comment
-file <- file \%>\%
+file <- file |>
   drive_share(
     role = "commenter",
     type = "user",
@@ -78,7 +78,7 @@ file <- file \%>\%
   )
 
 # Let a different specific person edit and customize the email notification
-file <- file \%>\%
+file <- file |>
   drive_share(
     role = "writer",
     type = "user",
@@ -87,7 +87,7 @@ file <- file \%>\%
   )
 
 # Let anyone read the file
-file <- file \%>\%
+file <- file |>
   drive_share(role = "reader", type = "anyone")
 # Single-purpose wrapper function for this
 drive_share_anyone(file)

--- a/man/drive_trash.Rd
+++ b/man/drive_trash.Rd
@@ -30,7 +30,7 @@ Move Drive files to or from trash
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # Create a file and put it in the trash.
-file <- drive_example_remote("chicken.txt") \%>\%
+file <- drive_example_remote("chicken.txt") |>
   drive_cp("chicken-trash.txt")
 drive_trash("chicken-trash.txt")
 

--- a/man/drive_update.Rd
+++ b/man/drive_update.Rd
@@ -36,21 +36,21 @@ depending on whether the Drive file already exists, see \code{\link[=drive_put]{
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # Create a new file, so we can update it
-x <- drive_example_remote("chicken.csv") \%>\%
+x <- drive_example_remote("chicken.csv") |>
   drive_cp()
 
 # Update the file with new media
-x <- x \%>\%
+x <- x |>
   drive_update(drive_example_local("chicken.txt"))
 
 # Update the file with new metadata.
 # Notice here `name` is not an argument of `drive_update()`, we are passing
 # this to the API via the `...``
-x <- x \%>\%
+x <- x |>
   drive_update(name = "CHICKENS!")
 
 # Update the file with new media AND new metadata
-x <- x \%>\%
+x <- x |>
   drive_update(
     drive_example_local("chicken.txt"),
     name = "chicken-poem-again.txt"

--- a/man/drive_upload.Rd
+++ b/man/drive_upload.Rd
@@ -82,11 +82,11 @@ depending on whether the Drive file already exists, see \code{\link[=drive_put]{
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # upload a csv file
-chicken_csv <- drive_example_local("chicken.csv") \%>\%
+chicken_csv <- drive_example_local("chicken.csv") |>
   drive_upload("chicken-upload.csv")
 
 # or convert it to a Google Sheet
-chicken_sheet <- drive_example_local("chicken.csv") \%>\%
+chicken_sheet <- drive_example_local("chicken.csv") |>
   drive_upload(
     name = "chicken-sheet-upload.csv",
     type = "spreadsheet"
@@ -96,10 +96,10 @@ chicken_sheet <- drive_example_local("chicken.csv") \%>\%
 drive_browse(chicken_sheet)
 
 # Clean up
-drive_find("chicken.*upload") \%>\% drive_rm()
+drive_find("chicken.*upload") |> drive_rm()
 
 # Upload a file and, at the same time, star it
-chicken <- drive_example_local("chicken.jpg") \%>\%
+chicken <- drive_example_local("chicken.jpg") |>
   drive_upload(starred = "true")
 
 # Is is really starred? YES
@@ -111,14 +111,14 @@ drive_rm(chicken)
 # `overwrite = FALSE` errors if something already exists at target filepath
 # THIS WILL ERROR!
 drive_create("name-squatter-upload")
-drive_example_local("chicken.jpg") \%>\%
+drive_example_local("chicken.jpg") |>
   drive_upload(
     name = "name-squatter-upload",
     overwrite = FALSE
   )
 
 # `overwrite = TRUE` moves the existing item to trash, then proceeds
-chicken <- drive_example_local("chicken.jpg") \%>\%
+chicken <- drive_example_local("chicken.jpg") |>
   drive_upload(
     name = "name-squatter-upload",
     overwrite = TRUE

--- a/man/googledrive-package.Rd
+++ b/man/googledrive-package.Rd
@@ -25,7 +25,7 @@ tibble". This is a data frame with one row per file. A dribble is returned
 give people what they want (file name), track what the API wants (file id),
 and to hold the metadata needed for general file operations.
 
-googledrive is "pipe-friendly" and, in fact, re-exports \verb{\%>\%}, but does not
+googledrive is "pipe-friendly" and, in fact, re-exports \verb{|>}, but does not
 require its use.
 
 Please see the googledrive website for full documentation:

--- a/man/shortcut_create.Rd
+++ b/man/shortcut_create.Rd
@@ -63,19 +63,19 @@ sc1 <- shortcut_create(src_file)
 # This shortcut could now be moved, renamed, etc.
 
 # Create a shortcut in the default location with a custom name
-sc2 <- src_file \%>\%
+sc2 <- src_file |>
   shortcut_create(name = "chicken_sheet_second_shortcut")
 
 # Create a folder, then put a shortcut there, with default name
 folder <- drive_mkdir("chicken_sheet_shortcut_folder")
-sc3 <- src_file \%>\%
+sc3 <- src_file |>
   shortcut_create(folder)
 
 # Look at all these shortcuts
 (dat <- drive_find("chicken_sheet", type = "shortcut"))
 
 # Confirm the shortcuts all target the original file
-dat <- dat \%>\%
+dat <- dat |>
   drive_reveal("shortcut_details")
 purrr::map_chr(dat$shortcut_details, "targetId")
 as_id(src_file)

--- a/man/shortcut_resolve.Rd
+++ b/man/shortcut_resolve.Rd
@@ -38,15 +38,15 @@ specific error.
 \examples{
 \dontshow{if (drive_has_token()) withAutoprint(\{ # examplesIf}
 # Create a file to make a shortcut to
-file <- drive_example_remote("chicken_sheet") \%>\%
+file <- drive_example_remote("chicken_sheet") |>
   drive_cp(name = "chicken-sheet-for-shortcut")
 
 # Create a shortcut
-sc1 <- file \%>\%
+sc1 <- file |>
   shortcut_create(name = "shortcut-1")
 
 # Create a second shortcut by copying the first
-sc1 <- sc1 \%>\%
+sc1 <- sc1 |>
   drive_cp(name = "shortcut-2")
 
 # Get the shortcuts

--- a/tests/testthat/driver.R
+++ b/tests/testthat/driver.R
@@ -29,11 +29,11 @@ test_files <- list.files(
   full.names = TRUE
 )
 
-clean_code <- test_files %>%
-  map(do_one, chunk = "clean") %>%
+clean_code <- test_files |>
+  map(do_one, chunk = "clean") |>
   compact()
-setup_code <- test_files %>%
-  map(do_one, chunk = "setup") %>%
+setup_code <- test_files |>
+  map(do_one, chunk = "setup") |>
   compact()
 
 header <- "

--- a/tests/testthat/test-drive_cp.R
+++ b/tests/testthat/test-drive_cp.R
@@ -39,8 +39,8 @@ test_that("drive_cp() can copy file in place", {
     cp_file <- drive_cp(file, name = cp_name),
     type = "message"
   )
-  drive_cp_message <- drive_cp_message %>%
-    scrub_filepath(cp_name) %>%
+  drive_cp_message <- drive_cp_message |>
+    scrub_filepath(cp_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_cp_message)
@@ -70,8 +70,8 @@ test_that("drive_cp() can copy a file into a different folder", {
     cp_file <- drive_cp(file, path = folder, name = cp_name),
     type = "message"
   )
-  drive_cp_message <- drive_cp_message %>%
-    scrub_filepath(cp_name) %>%
+  drive_cp_message <- drive_cp_message |>
+    scrub_filepath(cp_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_cp_message)
@@ -124,8 +124,8 @@ test_that("drive_cp() takes name, assumes path is folder if both are specified",
     ),
     type = "message"
   )
-  drive_cp_message <- drive_cp_message %>%
-    scrub_filepath(cp_name) %>%
+  drive_cp_message <- drive_cp_message |>
+    scrub_filepath(cp_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_cp_message)

--- a/tests/testthat/test-drive_download.R
+++ b/tests/testthat/test-drive_download.R
@@ -48,9 +48,9 @@ test_that("drive_download() downloads a file and adds local_path column", {
     type = "message"
   )
   # the order of scrubbing matters here
-  drive_download_message <- drive_download_message %>%
-    scrub_filepath(download_filepath) %>%
-    scrub_filepath(file_to_download) %>%
+  drive_download_message <- drive_download_message |>
+    scrub_filepath(download_filepath) |>
+    scrub_filepath(file_to_download) |>
     scrub_file_id()
 
   expect_snapshot(
@@ -83,9 +83,9 @@ test_that("drive_download() converts with explicit `type`", {
     ),
     type = "message"
   )
-  drive_download_message <- drive_download_message %>%
-    scrub_filepath(download_filename) %>%
-    scrub_filepath(file_to_download) %>%
+  drive_download_message <- drive_download_message |>
+    scrub_filepath(download_filename) |>
+    scrub_filepath(file_to_download) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_download_message)
@@ -110,9 +110,9 @@ test_that("drive_download() converts with type implicit in `path`", {
     ),
     type = "message"
   )
-  drive_download_message <- drive_download_message %>%
-    scrub_filepath(download_filename) %>%
-    scrub_filepath(file_to_download) %>%
+  drive_download_message <- drive_download_message |>
+    scrub_filepath(download_filename) |>
+    scrub_filepath(file_to_download) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_download_message)
@@ -137,9 +137,9 @@ test_that("drive_download() converts using default MIME type, if necessary", {
     ),
     type = "message"
   )
-  drive_download_message <- drive_download_message %>%
-    scrub_filepath(download_filename) %>%
-    scrub_filepath(file_to_download) %>%
+  drive_download_message <- drive_download_message |>
+    scrub_filepath(download_filename) |>
+    scrub_filepath(file_to_download) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_download_message)

--- a/tests/testthat/test-drive_get.R
+++ b/tests/testthat/test-drive_get.R
@@ -143,8 +143,8 @@ test_that("drive_reveal_path() puts trailing slash on a folder", {
   skip_if_offline()
 
   out <- drive_find(nm_("thing01"), type = "folder")
-  out <- out %>% drive_reveal_path()
-  out <- out %>% promote("mimeType")
+  out <- out |> drive_reveal_path()
+  out <- out |> promote("mimeType")
   expect_match(out$path, "/$")
 })
 

--- a/tests/testthat/test-drive_ls.R
+++ b/tests/testthat/test-drive_ls.R
@@ -92,9 +92,9 @@ test_that("drive_ls() list contents of the target of a folder shortcut", {
     indirect_ls <- drive_ls(shortcut_name),
     type = "message"
   )
-  drive_ls_message <- drive_ls_message %>%
-    scrub_filepath(target_name) %>%
-    scrub_filepath(shortcut_name) %>%
+  drive_ls_message <- drive_ls_message |>
+    scrub_filepath(target_name) |>
+    scrub_filepath(shortcut_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_ls_message)

--- a/tests/testthat/test-drive_mv.R
+++ b/tests/testthat/test-drive_mv.R
@@ -37,9 +37,9 @@ test_that("drive_mv() can rename file", {
     file <- drive_mv(file, name = name_2),
     type = "message"
   )
-  drive_mv_message <- drive_mv_message %>%
-    scrub_filepath(name_1) %>%
-    scrub_filepath(name_2) %>%
+  drive_mv_message <- drive_mv_message |>
+    scrub_filepath(name_1) |>
+    scrub_filepath(name_2) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_mv_message)
@@ -64,8 +64,8 @@ test_that("drive_mv() can move a file into a folder given as path", {
     mv_file <- drive_mv(mv_file, paste0(nm_("move-files-into-me"), "/")),
     type = "message"
   )
-  drive_mv_message <- drive_mv_message %>%
-    scrub_filepath(mv_name) %>%
+  drive_mv_message <- drive_mv_message |>
+    scrub_filepath(mv_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_mv_message)
@@ -95,8 +95,8 @@ test_that("drive_mv() can move a file into a folder given as dribble", {
     mv_file <- drive_mv(mv_file, destination),
     type = "message"
   )
-  drive_mv_message <- drive_mv_message %>%
-    scrub_filepath(mv_name) %>%
+  drive_mv_message <- drive_mv_message |>
+    scrub_filepath(mv_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_mv_message)
@@ -122,9 +122,9 @@ test_that("drive_mv() can rename and move, using `path` and `name`", {
     mv_file <- drive_mv(mv_file, nm_("move-files-into-me"), name_2),
     type = "message"
   )
-  drive_mv_message <- drive_mv_message %>%
-    scrub_filepath(name_1) %>%
-    scrub_filepath(name_2) %>%
+  drive_mv_message <- drive_mv_message |>
+    scrub_filepath(name_1) |>
+    scrub_filepath(name_2) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_mv_message)
@@ -152,9 +152,9 @@ test_that("drive_mv() can rename and move, using `path` only", {
     ),
     type = "message"
   )
-  drive_mv_message <- drive_mv_message %>%
-    scrub_filepath(name_1) %>%
-    scrub_filepath(name_2) %>%
+  drive_mv_message <- drive_mv_message |>
+    scrub_filepath(name_1) |>
+    scrub_filepath(name_2) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(drive_mv_message)

--- a/tests/testthat/test-drive_put.R
+++ b/tests/testthat/test-drive_put.R
@@ -36,9 +36,9 @@ test_that("drive_put() works", {
     original <- drive_put(local_file),
     type = "message"
   )
-  first_put <- first_put %>%
-    scrub_filepath(local_file) %>%
-    scrub_filepath(put_file) %>%
+  first_put <- first_put |>
+    scrub_filepath(local_file) |>
+    scrub_filepath(put_file) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(first_put)
@@ -59,8 +59,8 @@ test_that("drive_put() works", {
     second <- drive_put(local_file),
     type = "message"
   )
-  second_put <- second_put %>%
-    scrub_filepath(put_file) %>%
+  second_put <- second_put |>
+    scrub_filepath(put_file) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(second_put)

--- a/tests/testthat/test-drive_update.R
+++ b/tests/testthat/test-drive_update.R
@@ -58,7 +58,7 @@ test_that("drive_update() can update metadata only", {
   defer_drive_rm(me_("update-me"))
 
   updatee <- drive_cp(nm_("update-fodder"), name = me_("update-me"))
-  out <- drive_update(updatee, starred = TRUE) %>% promote("starred")
+  out <- drive_update(updatee, starred = TRUE) |> promote("starred")
   expect_true(out$starred)
 })
 

--- a/tests/testthat/test-shortcut.R
+++ b/tests/testthat/test-shortcut.R
@@ -45,8 +45,8 @@ test_that("shortcut_create() works", {
     type = "message"
   )
   defer_drive_rm(sc)
-  shortcut_create_message <- shortcut_create_message %>%
-    scrub_filepath(sc_name) %>%
+  shortcut_create_message <- shortcut_create_message |>
+    scrub_filepath(sc_name) |>
     scrub_file_id()
   expect_snapshot(
     write_utf8(shortcut_create_message)

--- a/vignettes/articles/example-files.Rmd
+++ b/vignettes/articles/example-files.Rmd
@@ -5,7 +5,7 @@ title: "Example Files"
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>", 
+  comment = "#>",
   error = TRUE
 )
 ```
@@ -36,21 +36,21 @@ basename(x)
 You can filter the files by providing a regular expression.
 
 ```{r}
-drive_examples_local("csv") %>% basename()
+drive_examples_local("csv") |> basename()
 ```
 
 If you want exactly one file, use the singular `drive_example_local()` and provide the file's name (or any sufficiently specific regular expression):
 
 ```{r}
-drive_examples_local("chicken.jpg") %>% basename()
+drive_examples_local("chicken.jpg") |> basename()
 
-drive_examples_local("imdb") %>% basename()
+drive_examples_local("imdb") |> basename()
 ```
 
 Here's how you might use one of these examples to start demonstrating something with googledrive:
 
 ```{r eval = FALSE}
-new_google_sheet <- drive_examples_local("chicken.csv") %>% 
+new_google_sheet <- drive_examples_local("chicken.csv") |>
   drive_upload(type = "spreadsheet")
 # ... example or reprex continues ...
 ```
@@ -61,7 +61,7 @@ Call `drive_examples_remote()` to get a `dribble` of the remote example files.
 Here I also reveal their MIME type.
 
 ```{r}
-drive_examples_remote() %>% 
+drive_examples_remote() |>
   drive_reveal("mime_type")
 ```
 
@@ -73,7 +73,7 @@ You'll notice there are two files that aren't among the local example files, but
 Here's a clickable table of the remote example files:
 
 ```{r include = FALSE}
-dat <- drive_examples_remote() %>% 
+dat <- drive_examples_remote() |>
   drive_reveal("webViewLink")
 dat2 <- tibble::tibble(
   `name (these are links)` =  glue::glue_data(dat, "[{name}]({web_view_link})"),
@@ -98,7 +98,7 @@ drive_example_remote("logo")
 Here's how you might use one of these examples to start demonstrating something with googledrive:
 
 ```{r eval = FALSE}
-new_google_doc <- drive_examples_remote("chicken_doc") %>% 
+new_google_doc <- drive_examples_remote("chicken_doc") |>
   drive_cp(name = "I have a chicken problem")
 # ... example or reprex continues ...
 ```

--- a/vignettes/articles/permissions.Rmd
+++ b/vignettes/articles/permissions.Rmd
@@ -42,8 +42,8 @@ Let's upload a file and view its permissions.
 ```{r}
 library(googledrive)
 
-file <- drive_example_local("chicken.txt") %>%
-  drive_upload(name = "chicken-perm-article.txt") %>% 
+file <- drive_example_local("chicken.txt") |>
+  drive_upload(name = "chicken-perm-article.txt") |>
   drive_reveal("permissions")
 
 file
@@ -54,7 +54,7 @@ file
 Let's give a specific person permission to edit this file and a customized message, using the `emailAddress` and `emailMessage` parameters.
 
 ```{r, eval = FALSE}
-file <- file %>%
+file <- file |>
   drive_share(
     role = "writer",
     type = "user",
@@ -66,14 +66,14 @@ file <- file %>%
 Let's say we also want "anyone with a link" to be able to read the file.
 
 ```{r eval = FALSE}
-file <- file %>%
+file <- file |>
   drive_share(role = "reader", type = "anyone")
 ```
 
 This comes up often enough that we've made a convenience wrapper:
 
 ```{r}
-file <- file %>%
+file <- file |>
   drive_share_anyone()
 file
 ```
@@ -101,10 +101,10 @@ We've suppressed execution of the above chunk but here's some static, indicative
 
 ```{r eval = FALSE}
 #> # A tibble: 3 x 5
-#>   id           name            type   role  email                      
-#>   <chr>        <chr>           <chr>  <chr> <chr>                      
-#> 1 12345678901… Serena Somebody user   writ… serena@example.com          
-#> 2 anyoneWithL… NA              anyone read… NA                         
+#>   id           name            type   role  email
+#>   <chr>        <chr>           <chr>  <chr> <chr>
+#> 1 12345678901… Serena Somebody user   writ… serena@example.com
+#> 2 anyoneWithL… NA              anyone read… NA
 #> 3 98765432109… Orville Owner   user   owner orville@example.com
 ```
 


### PR DESCRIPTION
Looks mostly clean, I added a weird looking anonymous function
to an example for `drive_read_string()` to avoid needd R 4.3.0,
which is the first version that supports `_[[1]]` in a chain.