### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,121 +9,122 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-hide-below="1200" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="googledrive.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 news:
   releases:
-    - text: "Version 2.0.0"
-      href: https://www.tidyverse.org/blog/2021/07/googledrive-2-0-0/
-    - text: "Version 1.0.0"
-      href: https://www.tidyverse.org/blog/2019/08/googledrive-1-0-0/
+  - text: "Version 2.0.0"
+    href: https://www.tidyverse.org/blog/2021/07/googledrive-2-0-0/
+  - text: "Version 1.0.0"
+    href: https://www.tidyverse.org/blog/2019/08/googledrive-1-0-0/
 
 articles:
-  - title: Common tasks
-    navbar: ~
-    contents:
-    - googledrive
-    - articles/file-identification
-    - articles/multiple-files
-    - articles/permissions
+- title: Common tasks
+  navbar:
+  contents:
+  - googledrive
+  - articles/file-identification
+  - articles/multiple-files
+  - articles/permissions
 
-  - title: Package configuration
-    navbar: Package configuration
-    contents:
-    - articles/bring-your-own-client
+- title: Package configuration
+  navbar: Package configuration
+  contents:
+  - articles/bring-your-own-client
 
-  - title: Developer
-    desc: Articles documenting internal matters
-    contents:
-    - articles/example-files
-    - articles/messages-and-errors
+- title: Developer
+  desc: Articles documenting internal matters
+  contents:
+  - articles/example-files
+  - articles/messages-and-errors
 
 reference:
-  - title: "Reach out and touch your files"
-    desc: >
-      Retrieve metadata on your Drive files so you can act on them
-    contents:
-      - drive_find
-      - drive_ls
-      - drive_get
-      - drive_reveal
-      - drive_browse
-      - starts_with("drive_read")
-  - title: "File creation and deletion"
-    desc: >
-      Create or delete Drive files and folders
-    contents:
-      - drive_upload
-      - drive_put
-      - drive_download
-      - drive_create
-      - drive_mkdir
-      - drive_cp
-      - drive_mv
-      - drive_rename
-      - drive_update
-      - drive_trash
-      - drive_empty_trash
-      - drive_rm
-      - starts_with("drive_example")
-  - title: "Share your files with the world"
-    desc: >
-      View or change the sharing and publishing status of Drive files
-    contents:
-      - drive_publish
-      - drive_unpublish
-      - drive_share
-      - drive_reveal
-      - drive_link
-  - title: "Shared drives"
-    desc: >
-      Manipulate and explore shared drives
-    contents:
-      - matches("shared_drive")
-  - title: "Shortcuts"
-    desc: >
-      Similar to local file shortcuts, aliases, or symbolic links
-    contents:
-      - matches("shortcut")
-  - title: "Dribble object"
-    desc: >
-      Metadata about Drive files is stored in a "Drive tibble" a.k.a. a dribble
-    contents:
-      - dribble
-      - as_dribble
-      - drive_reveal
-      - as_id
-      - dribble-checks
-  - title: "Authorization"
-    desc: >
-      Take explicit control of the Google auth status or examine current state
-    contents:
-      - drive_user
-      - drive_about
-      - drive_auth
-      - drive_deauth
-      - drive_auth_configure
-      - drive_scopes
-  - title: "Drive API spec"
-    desc: >
-      Summon info about or check input against the Drive API spec
-    contents:
-      - starts_with("drive_endpoint")
-      - drive_extension
-      - drive_fields
-      - drive_mime_type
-      - expose
-  - title: "Programming around the Drive API"
-    desc: >
-      Low-level functions used internally and made available for programming
-    contents:
-      - request_generate
-      - request_make
-      - do_request
-      - do_paginated_request
-      - drive_api_key
-      - drive_token
-      - drive_has_token
-  - title: "Package-level configuration"
-    contents:
-      - googledrive-configuration
+- title: "Reach out and touch your files"
+  desc: >
+    Retrieve metadata on your Drive files so you can act on them
+  contents:
+  - drive_find
+  - drive_ls
+  - drive_get
+  - drive_reveal
+  - drive_browse
+  - starts_with("drive_read")
+- title: "File creation and deletion"
+  desc: >
+    Create or delete Drive files and folders
+  contents:
+  - drive_upload
+  - drive_put
+  - drive_download
+  - drive_create
+  - drive_mkdir
+  - drive_cp
+  - drive_mv
+  - drive_rename
+  - drive_update
+  - drive_trash
+  - drive_empty_trash
+  - drive_rm
+  - starts_with("drive_example")
+- title: "Share your files with the world"
+  desc: >
+    View or change the sharing and publishing status of Drive files
+  contents:
+  - drive_publish
+  - drive_unpublish
+  - drive_share
+  - drive_reveal
+  - drive_link
+- title: "Shared drives"
+  desc: >
+    Manipulate and explore shared drives
+  contents:
+  - matches("shared_drive")
+- title: "Shortcuts"
+  desc: >
+    Similar to local file shortcuts, aliases, or symbolic links
+  contents:
+  - matches("shortcut")
+- title: "Dribble object"
+  desc: >
+    Metadata about Drive files is stored in a "Drive tibble" a.k.a. a dribble
+  contents:
+  - dribble
+  - as_dribble
+  - drive_reveal
+  - as_id
+  - dribble-checks
+- title: "Authorization"
+  desc: >
+    Take explicit control of the Google auth status or examine current state
+  contents:
+  - drive_user
+  - drive_about
+  - drive_auth
+  - drive_deauth
+  - drive_auth_configure
+  - drive_scopes
+- title: "Drive API spec"
+  desc: >
+    Summon info about or check input against the Drive API spec
+  contents:
+  - starts_with("drive_endpoint")
+  - drive_extension
+  - drive_fields
+  - drive_mime_type
+  - expose
+- title: "Programming around the Drive API"
+  desc: >
+    Low-level functions used internally and made available for programming
+  contents:
+  - request_generate
+  - request_make
+  - do_request
+  - do_paginated_request
+  - drive_api_key
+  - drive_token
+  - drive_has_token
+- title: "Package-level configuration"
+  contents:
+  - googledrive-configuration


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of googledrive website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/googledrive-1200.png)

At 992px browser width:

![Screenshot of googledrive website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/googledrive-992.png)

At 991px browser width:

![Screenshot of googledrive website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/googledrive-991.png)

