### PR TITLE
Update Plausible analytics snippet

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,7 +9,12 @@ template:
 
   includes:
     in_header: |
-      <script defer data-domain="googledrive.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-qqzH9EITRTKkhlMOvLy7c.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
 
 news:
   releases:


### PR DESCRIPTION
## Summary

- Replace the old Plausible `<script defer data-domain=...>` tag with the new async snippet that includes `plausible.init()`

## Context

Plausible has updated their recommended tracking snippet. The new format uses `async` loading with an inline init script, and no longer requires the `data-domain` attribute.
